### PR TITLE
fix(invite): 补全配置键

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1468,7 +1468,27 @@
     "stagedDissolveTitle": "Dissolve team and delete its accounts",
     "stagedDissolveBody": "Accounts created through {{name}}’s invite links will be deactivated now and permanently deleted after the grace period. Members who joined with their own Prism accounts are not affected.",
     "stagedDissolveConfirmLabel": "Type the team name ({{name}}) to confirm",
-    "stagedDissolveStart": "Start dissolution"
+    "stagedDissolveStart": "Start dissolution",
+    "enableInviteRegistration": "Enable team-invite registration",
+    "enableInviteRegistrationHint": "Lets authorised teams hand out links that create accounts. Each team still needs its own grant under Admin → Teams.",
+    "inviteRegMaxUsesCap": "Max uses per registration invite",
+    "inviteRegMaxUsesCapHint": "Ceiling on the usage limit a team may set. This is the only hard bound on registration volume.",
+    "inviteRegRatePerHour": "Registrations per hour per invite",
+    "inviteRegRatePerHourHint": "Per-IP limiting cannot bound a link shared to thousands of people; this can.",
+    "pendingTtlHours": "Unfinished registration TTL (hours)",
+    "pendingTtlHoursHint": "Accounts that never finish joining are deleted after this.",
+    "dissolveGraceHours": "Dissolution grace period (hours)",
+    "dissolveGraceHoursHint": "Between deactivating a dissolved team’s accounts and deleting them.",
+    "restrictedCapsLabel": "Features granted to invite-registered accounts (all denied by default)",
+    "capTeamCreate": "Create teams",
+    "capAppCreate": "Create applications",
+    "capDomainCreate": "Verify domains",
+    "capPatCreate": "Personal access tokens",
+    "capProfilePublic": "Public profile",
+    "capGpgManage": "GPG keys",
+    "capSelfConvert": "Convert to a full account",
+    "skipEmailForInvites": "Skip email verification for this team's invite registrations",
+    "requireEmailForInvites": "Require email verification again for this team's invite registrations"
   },
   "webhooks": {
     "title": "Webhooks",
@@ -1779,7 +1799,11 @@
     "joinFailed": "Could not complete the join",
     "pendingNotice": "Until you finish, your account can only manage its own security settings.",
     "unavailableTitle": "Not available",
-    "unavailableDesc": "This registration link is not active. Check the link, or ask whoever invited you for a new one."
+    "unavailableDesc": "This registration link is not active. Check the link, or ask whoever invited you for a new one.",
+    "usernameField": "Username",
+    "displayNameField": "Display name",
+    "emailField": "Email",
+    "passwordField": "Password"
   },
   "restriction": {
     "title": "Account type",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -1468,7 +1468,27 @@
     "stagedDissolveTitle": "解散团队并注销其账号",
     "stagedDissolveBody": "通过 {{name}} 的邀请链接创建的账号将立即停用，并在宽限期结束后永久删除。用自己的 Prism 账号加入的成员不受影响。",
     "stagedDissolveConfirmLabel": "输入团队名称（{{name}}）以确认",
-    "stagedDissolveStart": "开始解散"
+    "stagedDissolveStart": "开始解散",
+    "enableInviteRegistration": "启用团队邀请链接注册",
+    "enableInviteRegistrationHint": "允许已授权的团队发放可创建账号的链接。每个团队仍需在「管理 → 团队」中单独获得授权。",
+    "inviteRegMaxUsesCap": "单个注册邀请的次数上限",
+    "inviteRegMaxUsesCapHint": "团队可设置的使用次数天花板。这是注册总量唯一的硬边界。",
+    "inviteRegRatePerHour": "单个邀请每小时注册次数",
+    "inviteRegRatePerHourHint": "按 IP 限流约束不了被广传的链接，这一项可以。",
+    "pendingTtlHours": "未完成注册的存活时长（小时）",
+    "pendingTtlHoursHint": "始终未完成加入的账号会在此之后被删除。",
+    "dissolveGraceHours": "解散宽限期（小时）",
+    "dissolveGraceHoursHint": "从停用被解散团队的账号到实际删除之间的间隔。",
+    "restrictedCapsLabel": "放开给邀请注册账号的功能（默认全部拒绝）",
+    "capTeamCreate": "创建团队",
+    "capAppCreate": "创建应用",
+    "capDomainCreate": "验证域名",
+    "capPatCreate": "个人访问令牌",
+    "capProfilePublic": "公开主页",
+    "capGpgManage": "GPG 密钥",
+    "capSelfConvert": "转换为完整账号",
+    "skipEmailForInvites": "让该团队的邀请注册跳过邮箱验证",
+    "requireEmailForInvites": "恢复该团队邀请注册的邮箱验证要求"
   },
   "webhooks": {
     "title": "Webhooks",
@@ -1779,7 +1799,11 @@
     "joinFailed": "加入失败",
     "pendingNotice": "在完成之前，此账号只能管理自己的安全设置。",
     "unavailableTitle": "不可用",
-    "unavailableDesc": "该注册链接当前未启用。请检查链接，或向邀请你的人索取一个新的。"
+    "unavailableDesc": "该注册链接当前未启用。请检查链接，或向邀请你的人索取一个新的。",
+    "usernameField": "用户名",
+    "displayNameField": "显示名",
+    "emailField": "邮箱",
+    "passwordField": "密码"
   },
   "restriction": {
     "title": "账号类型",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1326,12 +1326,7 @@ export const api = {
       /** Total across the team, not the page. */
       member_count: number;
       member_page: { page: number; limit: number };
-    }>(
-      "GET",
-      `/teams/${id}`,
-      undefined,
-      getToken(),
-    ),
+    }>("GET", `/teams/${id}`, undefined, getToken()),
   updateTeam: (
     id: string,
     body: {
@@ -1842,6 +1837,24 @@ export interface SitePublicConfig {
    *  effectively requires the factor regardless of the per-team flag. */
   default_team_require_2fa: boolean;
   default_team_require_verified_email: boolean;
+  /** Master switch for team-invite registration. Off by default: turning it
+   *  on is what lets a team owner mint accounts at all, and even then each
+   *  team needs its own site-admin grant. */
+  enable_team_invite_registration: boolean;
+  /** Ceiling on the usage limit a team may set on a registration-capable
+   *  invite — the only hard bound on registration volume. */
+  team_invite_registration_max_uses_cap: number;
+  /** Registrations per hour per invite. Per-IP limiting cannot bound a link
+   *  shared to thousands of people. */
+  team_invite_registration_rate_per_hour: number;
+  /** Features granted to invite-registered accounts. Absent keys fall back
+   *  to the built-in defaults, which deny everything. */
+  restricted_user_capabilities: Partial<Record<string, boolean>>;
+  /** How long an unfinished registration survives before it is reaped. */
+  restricted_pending_ttl_hours: number;
+  /** Grace period between a dissolution deactivating accounts and the
+   *  reaper deleting them. */
+  restricted_dissolve_grace_hours: number;
   /** Master switch for the sub-team feature. When `false`, the UI hides
    *  the Sub-teams tab + dialog and the server rejects every sub-team
    *  endpoint. */
@@ -2338,6 +2351,9 @@ export interface AdminTeam {
    *  links. The admin list surfaces it so the grant can be toggled inline. */
   invite_registration_granted: number;
   invite_registration_enabled: number;
+  /** Site-level registration checks this team's invite path may skip.
+   *  Only email verification is exemptible. */
+  invite_registration_exemptions: { email_verification?: boolean };
   /** Non-null while a staged dissolution is in flight. */
   dissolving_at: number | null;
   created_at: number;

--- a/src/pages/JoinRegister.tsx
+++ b/src/pages/JoinRegister.tsx
@@ -210,17 +210,17 @@ export function JoinRegister() {
               placeholder={t("join.invitePlaceholder")}
             />
           </Field>
-          <Field label={t("auth.username")} required>
+          <Field label={t("join.usernameField")} required>
             <Input value={form.username} onChange={update("username")} />
           </Field>
-          <Field label={t("auth.displayName")}>
+          <Field label={t("join.displayNameField")}>
             <Input
               value={form.display_name}
               onChange={update("display_name")}
             />
           </Field>
           {info.collects_email && (
-            <Field label={t("auth.email")} required>
+            <Field label={t("join.emailField")} required>
               <Input
                 type="email"
                 value={form.email}
@@ -228,7 +228,7 @@ export function JoinRegister() {
               />
             </Field>
           )}
-          <Field label={t("auth.password")} required>
+          <Field label={t("join.passwordField")} required>
             <PasswordInput
               value={form.password}
               onChange={(e) =>

--- a/src/pages/admin/AdminSettings.tsx
+++ b/src/pages/admin/AdminSettings.tsx
@@ -609,6 +609,130 @@ export function AdminSettings() {
                 onChange={(_, d) => set("inherit_team_domains", d.checked)}
               />
             </div>
+            <Switch
+              label={t("admin.enableInviteRegistration")}
+              checked={get("enable_team_invite_registration") ?? false}
+              onChange={(_, d) =>
+                set("enable_team_invite_registration", d.checked)
+              }
+            />
+            <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>
+              {t("admin.enableInviteRegistrationHint")}
+            </Text>
+            <div className={styles.subGroup}>
+              <Field
+                label={t("admin.inviteRegMaxUsesCap")}
+                hint={t("admin.inviteRegMaxUsesCapHint")}
+              >
+                <Input
+                  type="number"
+                  min={1}
+                  value={String(
+                    get("team_invite_registration_max_uses_cap") ?? 1000,
+                  )}
+                  onChange={(e) =>
+                    set(
+                      "team_invite_registration_max_uses_cap",
+                      Number(e.target.value),
+                    )
+                  }
+                  disabled={!(get("enable_team_invite_registration") ?? false)}
+                  style={{ width: 120 }}
+                />
+              </Field>
+              <Field
+                label={t("admin.inviteRegRatePerHour")}
+                hint={t("admin.inviteRegRatePerHourHint")}
+              >
+                <Input
+                  type="number"
+                  min={1}
+                  value={String(
+                    get("team_invite_registration_rate_per_hour") ?? 200,
+                  )}
+                  onChange={(e) =>
+                    set(
+                      "team_invite_registration_rate_per_hour",
+                      Number(e.target.value),
+                    )
+                  }
+                  disabled={!(get("enable_team_invite_registration") ?? false)}
+                  style={{ width: 120 }}
+                />
+              </Field>
+              <Field
+                label={t("admin.pendingTtlHours")}
+                hint={t("admin.pendingTtlHoursHint")}
+              >
+                <Input
+                  type="number"
+                  min={1}
+                  value={String(get("restricted_pending_ttl_hours") ?? 72)}
+                  onChange={(e) =>
+                    set("restricted_pending_ttl_hours", Number(e.target.value))
+                  }
+                  disabled={!(get("enable_team_invite_registration") ?? false)}
+                  style={{ width: 120 }}
+                />
+              </Field>
+              <Field
+                label={t("admin.dissolveGraceHours")}
+                hint={t("admin.dissolveGraceHoursHint")}
+              >
+                <Input
+                  type="number"
+                  min={1}
+                  value={String(get("restricted_dissolve_grace_hours") ?? 168)}
+                  onChange={(e) =>
+                    set(
+                      "restricted_dissolve_grace_hours",
+                      Number(e.target.value),
+                    )
+                  }
+                  disabled={!(get("enable_team_invite_registration") ?? false)}
+                  style={{ width: 120 }}
+                />
+              </Field>
+              <Text
+                size={200}
+                style={{ color: tokens.colorNeutralForeground3 }}
+              >
+                {t("admin.restrictedCapsLabel")}
+              </Text>
+              {(
+                [
+                  ["team:create", "admin.capTeamCreate"],
+                  ["app:create", "admin.capAppCreate"],
+                  ["domain:create", "admin.capDomainCreate"],
+                  ["pat:create", "admin.capPatCreate"],
+                  ["profile:public", "admin.capProfilePublic"],
+                  ["gpg:manage", "admin.capGpgManage"],
+                  ["self:convert", "admin.capSelfConvert"],
+                ] as const
+              ).map(([key, label]) => {
+                const caps =
+                  (get("restricted_user_capabilities") as Record<
+                    string,
+                    boolean
+                  > | null) ?? {};
+                return (
+                  <Switch
+                    key={key}
+                    label={t(label)}
+                    checked={caps[key] ?? false}
+                    disabled={
+                      !(get("enable_team_invite_registration") ?? false)
+                    }
+                    onChange={(_, d) =>
+                      set("restricted_user_capabilities", {
+                        ...caps,
+                        [key]: d.checked,
+                      })
+                    }
+                  />
+                );
+              })}
+            </div>
             <Field
               label={t("admin.ipv6RateLimitPrefix")}
               hint={t("admin.ipv6RateLimitPrefixHint")}

--- a/src/pages/admin/AdminSettings.tsx
+++ b/src/pages/admin/AdminSettings.tsx
@@ -166,6 +166,22 @@ export function AdminSettings() {
   const set = (key: keyof SiteConfig, value: unknown) =>
     setLocalConfig((c) => ({ ...c, [key]: value }));
 
+  // Read once — the whole invite-registration block keys its disabled state
+  // off this flag.
+  const inviteRegOn = get("enable_team_invite_registration") ?? false;
+
+  /** Numeric config setter that refuses to store a non-number.
+   *
+   *  `type="number"` does not prevent the field being momentarily empty, and
+   *  `Number("")` is 0 — which for a usage cap or a TTL is a live setting,
+   *  not a blank. Leave the previous value in place instead. */
+  const setNumber = (key: keyof SiteConfig, raw: string) => {
+    if (raw.trim() === "") return;
+    const n = Number(raw);
+    if (!Number.isFinite(n)) return;
+    set(key, n);
+  };
+
   const handleTestEmail = async () => {
     setTestingEmail(true);
     try {
@@ -611,7 +627,7 @@ export function AdminSettings() {
             </div>
             <Switch
               label={t("admin.enableInviteRegistration")}
-              checked={get("enable_team_invite_registration") ?? false}
+              checked={inviteRegOn}
               onChange={(_, d) =>
                 set("enable_team_invite_registration", d.checked)
               }
@@ -631,12 +647,12 @@ export function AdminSettings() {
                     get("team_invite_registration_max_uses_cap") ?? 1000,
                   )}
                   onChange={(e) =>
-                    set(
+                    setNumber(
                       "team_invite_registration_max_uses_cap",
-                      Number(e.target.value),
+                      e.target.value,
                     )
                   }
-                  disabled={!(get("enable_team_invite_registration") ?? false)}
+                  disabled={!inviteRegOn}
                   style={{ width: 120 }}
                 />
               </Field>
@@ -651,12 +667,12 @@ export function AdminSettings() {
                     get("team_invite_registration_rate_per_hour") ?? 200,
                   )}
                   onChange={(e) =>
-                    set(
+                    setNumber(
                       "team_invite_registration_rate_per_hour",
-                      Number(e.target.value),
+                      e.target.value,
                     )
                   }
-                  disabled={!(get("enable_team_invite_registration") ?? false)}
+                  disabled={!inviteRegOn}
                   style={{ width: 120 }}
                 />
               </Field>
@@ -669,9 +685,9 @@ export function AdminSettings() {
                   min={1}
                   value={String(get("restricted_pending_ttl_hours") ?? 72)}
                   onChange={(e) =>
-                    set("restricted_pending_ttl_hours", Number(e.target.value))
+                    setNumber("restricted_pending_ttl_hours", e.target.value)
                   }
-                  disabled={!(get("enable_team_invite_registration") ?? false)}
+                  disabled={!inviteRegOn}
                   style={{ width: 120 }}
                 />
               </Field>
@@ -684,12 +700,9 @@ export function AdminSettings() {
                   min={1}
                   value={String(get("restricted_dissolve_grace_hours") ?? 168)}
                   onChange={(e) =>
-                    set(
-                      "restricted_dissolve_grace_hours",
-                      Number(e.target.value),
-                    )
+                    setNumber("restricted_dissolve_grace_hours", e.target.value)
                   }
-                  disabled={!(get("enable_team_invite_registration") ?? false)}
+                  disabled={!inviteRegOn}
                   style={{ width: 120 }}
                 />
               </Field>

--- a/src/pages/admin/AdminTeams.tsx
+++ b/src/pages/admin/AdminTeams.tsx
@@ -28,6 +28,7 @@ import {
   DeleteRegular,
   DismissCircleRegular,
   EditRegular,
+  MailRegular,
   PersonAddRegular,
 } from "@fluentui/react-icons";
 import { useState } from "react";
@@ -71,6 +72,26 @@ export function AdminTeams() {
     name: string;
   } | null>(null);
   const [dissolveConfirm, setDissolveConfirm] = useState("");
+
+  // Email verification is the one site-level check a team's invite path may
+  // skip — it is the only one whose cost scales with the number of
+  // registrations. Captcha, proof-of-work and every rate limit stay on.
+  const handleToggleExemption = async (id: string, skipEmail: boolean) => {
+    setBusyTeam(id);
+    try {
+      await api.adminSetInviteRegistration(id, {
+        exemptions: { email_verification: skipEmail },
+      });
+      await qc.invalidateQueries({ queryKey: ["admin-teams"] });
+    } catch (err) {
+      showMsg?.(
+        "error",
+        err instanceof ApiError ? err.message : "Failed to update",
+      );
+    } finally {
+      setBusyTeam(null);
+    }
+  };
 
   const handleToggleGrant = async (id: string, granted: boolean) => {
     setBusyTeam(id);
@@ -226,6 +247,39 @@ export function AdminTeams() {
                           }
                         />
                       </Tooltip>
+                      {team.invite_registration_granted && (
+                        <Tooltip
+                          relationship="label"
+                          content={
+                            team.invite_registration_exemptions
+                              ?.email_verification
+                              ? t("admin.requireEmailForInvites")
+                              : t("admin.skipEmailForInvites")
+                          }
+                        >
+                          <Button
+                            size="small"
+                            appearance="subtle"
+                            disabled={busyTeam === team.id}
+                            icon={<MailRegular />}
+                            style={
+                              team.invite_registration_exemptions
+                                ?.email_verification
+                                ? {
+                                    color: tokens.colorPaletteYellowForeground1,
+                                  }
+                                : undefined
+                            }
+                            onClick={() =>
+                              handleToggleExemption(
+                                team.id,
+                                !team.invite_registration_exemptions
+                                  ?.email_verification,
+                              )
+                            }
+                          />
+                        </Tooltip>
+                      )}
                       {team.invite_registration_granted && (
                         <Tooltip
                           relationship="label"

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,24 @@ export interface SiteConfig {
   default_team_profile_show_sub_teams: boolean;
   default_team_require_2fa: boolean;
   default_team_require_verified_email: boolean;
+  /** Master switch for team-invite registration. Off by default: turning it
+   *  on is what lets a team owner mint accounts at all, and even then each
+   *  team needs its own site-admin grant. */
+  enable_team_invite_registration: boolean;
+  /** Ceiling on the usage limit a team may set on a registration-capable
+   *  invite — the only hard bound on registration volume. */
+  team_invite_registration_max_uses_cap: number;
+  /** Registrations per hour per invite. Per-IP limiting cannot bound a link
+   *  shared to thousands of people. */
+  team_invite_registration_rate_per_hour: number;
+  /** Features granted to invite-registered accounts. Absent keys fall back
+   *  to the built-in defaults, which deny everything. */
+  restricted_user_capabilities: Partial<Record<string, boolean>>;
+  /** How long an unfinished registration survives before it is reaped. */
+  restricted_pending_ttl_hours: number;
+  /** Grace period between a dissolution deactivating accounts and the
+   *  reaper deleting them. */
+  restricted_dissolve_grace_hours: number;
   /** Master switch for the sub-team feature. When false the server rejects
    *  every sub-team endpoint and the UI hides sub-team affordances. */
   enable_sub_teams: boolean;

--- a/worker/lib/userCapabilities.ts
+++ b/worker/lib/userCapabilities.ts
@@ -23,6 +23,7 @@
 
 import { getConfigValue } from "./config";
 import type {
+  InviteRegistrationExemptions,
   RestrictedCapabilities,
   RestrictedCapability,
   UserRow,
@@ -341,6 +342,33 @@ export async function subtreeHasRestrictedMembers(
     .bind(...ids)
     .first<{ x: number }>();
   return !!row;
+}
+
+/**
+ * Tolerant parse of `teams.invite_registration_exemptions`.
+ *
+ * Malformed content degrades to "nothing exempted" rather than throwing. The
+ * admin team listing reads this column for every row, so one bad blob — a
+ * hand-edited row, a legacy write — would otherwise take the whole listing
+ * down with it. Falling back also fails *safe*: an unreadable exemption
+ * means the check stays enforced.
+ */
+export function parseInviteRegistrationExemptions(
+  raw: string | null,
+): InviteRegistrationExemptions {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+      return {};
+    const bag = parsed as Record<string, unknown>;
+    const out: InviteRegistrationExemptions = {};
+    if (typeof bag.email_verification === "boolean")
+      out.email_verification = bag.email_verification;
+    return out;
+  } catch {
+    return {};
+  }
 }
 
 // ─── Synthetic addresses ─────────────────────────────────────────────────────

--- a/worker/routes/admin.ts
+++ b/worker/routes/admin.ts
@@ -57,7 +57,10 @@ import type {
 } from "../types";
 import { isUserLocked, isTeamLocked } from "../lib/lockdown";
 import { sanitizeRolePermissions } from "../lib/teamGroups";
-import { hasLiveRestrictedAccounts } from "../lib/userCapabilities";
+import {
+  hasLiveRestrictedAccounts,
+  sanitizeRestrictedCapabilities,
+} from "../lib/userCapabilities";
 import { hashLookupCandidate } from "../lib/secretCrypto";
 
 type AppEnv = { Bindings: Env; Variables: Variables };
@@ -173,6 +176,12 @@ app.patch("/config", async (c) => {
     "inherit_team_domains",
     "default_team_profile_show_sub_teams",
     "default_team_role_permissions",
+    "enable_team_invite_registration",
+    "team_invite_registration_max_uses_cap",
+    "team_invite_registration_rate_per_hour",
+    "restricted_user_capabilities",
+    "restricted_pending_ttl_hours",
+    "restricted_dissolve_grace_hours",
   ]);
 
   const updates: Record<string, unknown> = {};
@@ -235,6 +244,12 @@ app.patch("/config", async (c) => {
   if (updates.default_team_role_permissions !== undefined) {
     updates.default_team_role_permissions = sanitizeRolePermissions(
       updates.default_team_role_permissions,
+    );
+  }
+
+  if (updates.restricted_user_capabilities !== undefined) {
+    updates.restricted_user_capabilities = sanitizeRestrictedCapabilities(
+      updates.restricted_user_capabilities,
     );
   }
 
@@ -1867,6 +1882,11 @@ app.get("/teams", async (c) => {
         ...t,
         avatar_url: await proxyImageUrl(c.env.APP_URL, c.env.DB, t.avatar_url),
         unproxied_avatar_url: t.avatar_url,
+        // Parsed rather than raw JSON so the admin UI can toggle it without
+        // knowing the storage format.
+        invite_registration_exemptions: t.invite_registration_exemptions
+          ? (JSON.parse(t.invite_registration_exemptions) as unknown)
+          : {},
       })),
     ),
     total: count?.n ?? 0,

--- a/worker/routes/admin.ts
+++ b/worker/routes/admin.ts
@@ -59,6 +59,7 @@ import { isUserLocked, isTeamLocked } from "../lib/lockdown";
 import { sanitizeRolePermissions } from "../lib/teamGroups";
 import {
   hasLiveRestrictedAccounts,
+  parseInviteRegistrationExemptions,
   sanitizeRestrictedCapabilities,
 } from "../lib/userCapabilities";
 import { hashLookupCandidate } from "../lib/secretCrypto";
@@ -1883,10 +1884,11 @@ app.get("/teams", async (c) => {
         avatar_url: await proxyImageUrl(c.env.APP_URL, c.env.DB, t.avatar_url),
         unproxied_avatar_url: t.avatar_url,
         // Parsed rather than raw JSON so the admin UI can toggle it without
-        // knowing the storage format.
-        invite_registration_exemptions: t.invite_registration_exemptions
-          ? (JSON.parse(t.invite_registration_exemptions) as unknown)
-          : {},
+        // knowing the storage format. Tolerant, because this runs for every
+        // row in the listing and one malformed blob must not 500 the page.
+        invite_registration_exemptions: parseInviteRegistrationExemptions(
+          t.invite_registration_exemptions,
+        ),
       })),
     ),
     total: count?.n ?? 0,
@@ -2007,9 +2009,9 @@ app.patch("/teams/:id/invite-registration", async (c) => {
   return c.json({
     invite_registration_granted: updated?.invite_registration_granted === 1,
     invite_registration_enabled: updated?.invite_registration_enabled === 1,
-    invite_registration_exemptions: updated?.invite_registration_exemptions
-      ? (JSON.parse(updated.invite_registration_exemptions) as unknown)
-      : {},
+    invite_registration_exemptions: parseInviteRegistrationExemptions(
+      updated?.invite_registration_exemptions ?? null,
+    ),
   });
 });
 

--- a/worker/routes/invite-registration.ts
+++ b/worker/routes/invite-registration.ts
@@ -36,29 +36,14 @@ import {
   unmetRequirements,
   type EffectiveTeamRequirements,
 } from "../lib/teamRequirements";
-import { syntheticEmail } from "../lib/userCapabilities";
-import type {
-  InviteRegistrationExemptions,
-  TeamRow,
-  UserRow,
-  Variables,
-} from "../types";
+import {
+  parseInviteRegistrationExemptions,
+  syntheticEmail,
+} from "../lib/userCapabilities";
+import type { TeamRow, UserRow, Variables } from "../types";
 
 type AppEnv = { Bindings: Env; Variables: Variables };
 const app = new Hono<AppEnv>();
-
-/** Parse the site-admin-set exemptions blob, tolerating garbage. */
-function parseExemptions(raw: string | null): InviteRegistrationExemptions {
-  if (!raw) return {};
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
-      return {};
-    return parsed as InviteRegistrationExemptions;
-  } catch {
-    return {};
-  }
-}
 
 /**
  * Load a team that is currently able to mint accounts, or null.
@@ -126,7 +111,9 @@ async function effectiveRequirements(
     },
     floor,
   );
-  const exemptions = parseExemptions(team.invite_registration_exemptions);
+  const exemptions = parseInviteRegistrationExemptions(
+    team.invite_registration_exemptions,
+  );
   if (!exemptions.email_verification) return merged;
   // An exemption overrides the site floor as well as the team's own flag —
   // that is precisely what a site admin is granting when they set it, since
@@ -151,7 +138,9 @@ app.get("/join/:teamId", async (c) => {
 
   const requirements = await effectiveRequirements(c.env.DB, team);
   const config = await getConfig(c.env.DB);
-  const exemptions = parseExemptions(team.invite_registration_exemptions);
+  const exemptions = parseInviteRegistrationExemptions(
+    team.invite_registration_exemptions,
+  );
 
   return c.json({
     team: {
@@ -268,7 +257,9 @@ app.post("/auth/register-with-invite", async (c) => {
       429,
     );
 
-  const exemptions = parseExemptions(team.invite_registration_exemptions);
+  const exemptions = parseInviteRegistrationExemptions(
+    team.invite_registration_exemptions,
+  );
   const collectsEmail = !exemptions.email_verification;
 
   let email: string;

--- a/worker/routes/oauth.ts
+++ b/worker/routes/oauth.ts
@@ -44,6 +44,7 @@ import {
   checkAppAuthorizationAllowed,
   getRestrictionState,
   hasLiveRestrictedAccounts,
+  sanitizeRestrictedCapabilities,
 } from "../lib/userCapabilities";
 import {
   getGroupsForTeamMembers,
@@ -3951,6 +3952,11 @@ app.patch("/me/admin/config", async (c) => {
   if (updates.default_team_role_permissions !== undefined) {
     updates.default_team_role_permissions = sanitizeRolePermissions(
       updates.default_team_role_permissions,
+    );
+  }
+  if (updates.restricted_user_capabilities !== undefined) {
+    updates.restricted_user_capabilities = sanitizeRestrictedCapabilities(
+      updates.restricted_user_capabilities,
     );
   }
 


### PR DESCRIPTION
## Summary by Sourcery

在管理员界面中新增可配置的团队邀请注册控制，以及按团队配置的邮件验证豁免功能，这些功能由新的站点配置键和已净化的受限能力设置提供支持。

New Features:
- 暴露站点级设置，用于启用团队邀请注册、限制邀请使用次数、对注册进行限流、配置受限用户能力，以及控制待处理/解散状态的生命周期。
- 在管理 UI 中提供配置基于邀请的注册限制和受限能力的界面，并支持为邀请注册按团队切换邮箱验证豁免。

Enhancements:
- 在管理员团队列表中返回解析后的邀请注册豁免数据，使 UI 在不需要了解存储格式的情况下即可切换这些设置。
- 当通过管理员和自助管理员配置端点更新站点配置时，对受限用户能力设置进行净化处理。
- 将通过邀请加入的注册表单标签与专用的 i18n 键对齐，以适配邀请注册流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable team invite registration controls and per-team email verification exemptions to the admin interface, backed by new site config keys and sanitized restricted capability settings.

New Features:
- Expose site-level settings to enable team invite registration, cap invite usage, rate-limit registrations, configure restricted user capabilities, and control pending/dissolution lifetimes.
- Surface admin UI to configure invite-based registration limits and restricted capabilities, and to toggle per-team email verification exemptions for invite registrations.

Enhancements:
- Return parsed invite registration exemptions with admin team listings so the UI can toggle them without knowing the storage format.
- Sanitize restricted user capability settings when updating site configuration via both admin and self-admin config endpoints.
- Align join-by-invite registration form labels with dedicated i18n keys for the invite registration flow.

</details>