### PR TITLE
fix(audit): 修复团队角色变更同步与审计日志若干问题

### DIFF
--- a/src/components/AuditLog.tsx
+++ b/src/components/AuditLog.tsx
@@ -307,12 +307,9 @@ export function AuditLog({ base }: { base: string }) {
                             })
                           }
                         >
-                          {ev.resource_name ??
-                            `${ev.resource_type ?? ""}${
-                              ev.resource_id
-                                ? ` ${ev.resource_id.slice(0, 8)}`
-                                : ""
-                            }`}
+                          {ev.resource_name
+                            ? `${ev.resource_name}`
+                            : `${ev.resource_type ?? ""}${ev.resource_id ? ` / ${ev.resource_id.slice(0, 8)}` : ""}`}
                         </Text>
                       </Tooltip>
                     ) : (

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -63,7 +63,7 @@
     "closeMenu": "关闭菜单",
     "openMenu": "打开菜单",
     "signOut": "退出登录",
-    "auditLog": "审核日志"
+    "auditLog": "审计日志"
   },
   "auth": {
     "signIn": "登录",
@@ -759,7 +759,7 @@
     "requirementVerifiedEmailUnmet": "需要已验证的主邮箱。",
     "goToSecurity": "设置二次验证",
     "goToProfile": "验证邮箱",
-    "auditTab": "审核日志",
+    "auditTab": "审计日志",
     "groupsTab": "身份组",
     "groupsHeader": "身份组",
     "groupsDesc": "身份组是你贴在成员身上的标签。它不会改变任何人在 Prism 内部的权限，而是随成员信息下发给团队接入的应用，由这些应用拿去鉴权。",
@@ -1509,7 +1509,7 @@
     "defaultTeamProfileShowMembers": "团队：默认显示成员列表（每位成员自己的设置仍然适用）",
     "defaultTeamProfileShowSubTeams": "团队：默认在公开资料展示子团队列表",
     "webhooksMigrateTitle": "迁移旧版 Webhook",
-    "webhooksMigrateDesc": "将旧版 Webhook 系统中的 Webhook 导入到新的审核日志 Webhook 系统（作为通用 Webhook）。可安全地多次运行。",
+    "webhooksMigrateDesc": "将旧版 Webhook 系统中的 Webhook 导入到新的审计日志 Webhook 系统（作为通用 Webhook）。可安全地多次运行。",
     "webhooksMigrateButton": "迁移 Webhook",
     "webhooksMigrateSuccess": "已迁移 {{count}} 个（共 {{total}} 个）Webhook。",
     "webhooksMigrateFailed": "迁移 Webhook 失败。",
@@ -1683,7 +1683,7 @@
     "rulesetsStop": "匹配后停止处理后续规则",
     "rulesetActiveOverride": "已激活的规则集（\"{{name}}\"）正在覆盖下方的逐事件规则。",
     "rulesTab": "通知",
-    "auditTab": "审核日志"
+    "auditTab": "审计日志"
   },
   "verifyChoose": {
     "title": "验证您的邮箱",
@@ -1792,7 +1792,7 @@
     "metadata": "元数据",
     "backToLog": "返回日志",
     "webhooksTitle": "Webhook",
-    "webhooksHint": "Webhook 会将审核事件实时推送到 Discord、Telegram 或任意 HTTP 端点。",
+    "webhooksHint": "Webhook 会将审计事件实时推送到 Discord、Telegram 或任意 HTTP 端点。",
     "newWebhook": "新建 Webhook",
     "editWebhook": "编辑 Webhook",
     "noWebhooks": "暂无 Webhook。",
@@ -1828,7 +1828,7 @@
     "webhookSaved": "Webhook 已保存。",
     "webhookSaveFailed": "保存 Webhook 失败。",
     "webhookDeleteFailed": "删除 Webhook 失败。",
-    "pageTitle": "审核日志",
+    "pageTitle": "审计日志",
     "pageSubtitle": "你的登录、授权与账户活动记录（Transparent User Control）。"
   },
   "join": {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1108,6 +1108,13 @@ export const api = {
       {},
       getToken(),
     ),
+  adminRecoveryCodesStatus: () =>
+    request<{ total: number; unmigrated: number }>(
+      "GET",
+      "/admin/migrate-recovery-codes-status",
+      undefined,
+      getToken(),
+    ),
   adminSetInviteRegistration: (
     teamId: string,
     body: { granted?: boolean; exemptions?: { email_verification?: boolean } },
@@ -1274,6 +1281,13 @@ export const api = {
       "POST",
       "/audit/platform/migrate-legacy-webhooks",
       {},
+      getToken(),
+    ),
+  legacyWebhooksStatus: () =>
+    request<{ total: number; unmigrated: number }>(
+      "GET",
+      "/audit/platform/legacy-webhooks-status",
+      undefined,
       getToken(),
     ),
 

--- a/src/pages/admin/AdminSettings.tsx
+++ b/src/pages/admin/AdminSettings.tsx
@@ -137,6 +137,19 @@ export function AdminSettings() {
     enabled: tab === "danger",
   });
 
+  const { data: webhooksStatus, refetch: refetchWebhooksStatus } = useQuery({
+    queryKey: ["admin-legacy-webhooks-status"],
+    queryFn: api.legacyWebhooksStatus,
+    enabled: tab === "danger",
+  });
+
+  const { data: recoveryCodesStatus, refetch: refetchRecoveryCodesStatus } =
+    useQuery({
+      queryKey: ["admin-recovery-codes-status"],
+      queryFn: api.adminRecoveryCodesStatus,
+      enabled: tab === "danger",
+    });
+
   const { data: teamsAsUsersStatus, refetch: refetchTeamsAsUsersStatus } =
     useQuery({
       queryKey: ["admin-teams-as-users-status"],
@@ -244,6 +257,7 @@ export function AdminSettings() {
           total: res.total,
         }),
       );
+      await refetchWebhooksStatus();
     } catch (err) {
       showMsg(
         "error",
@@ -283,6 +297,7 @@ export function AdminSettings() {
         "success",
         t("admin.migrateRecoveryCodesSuccess", { count: res.migrated }),
       );
+      await refetchRecoveryCodesStatus();
     } catch (err) {
       showMsg(
         "error",
@@ -1650,7 +1665,10 @@ export function AdminSettings() {
             <Button
               appearance="outline"
               onClick={handleMigrateWebhooks}
-              disabled={migratingWebhooks}
+              disabled={
+                migratingWebhooks ||
+                (!!webhooksStatus && webhooksStatus.unmigrated === 0)
+              }
               icon={migratingWebhooks ? <Spinner size="tiny" /> : undefined}
             >
               {t("admin.webhooksMigrateButton")}
@@ -1763,7 +1781,10 @@ export function AdminSettings() {
             <Button
               appearance="outline"
               onClick={handleMigrateRecoveryCodes}
-              disabled={migratingCodes}
+              disabled={
+                migratingCodes ||
+                (!!recoveryCodesStatus && recoveryCodesStatus.unmigrated === 0)
+              }
               icon={migratingCodes ? <Spinner size="tiny" /> : undefined}
             >
               {t("admin.migrateRecoveryCodes")}

--- a/src/pages/teams/TeamDetail.tsx
+++ b/src/pages/teams/TeamDetail.tsx
@@ -330,6 +330,7 @@ export function TeamDetail() {
     try {
       await api.changeTeamMemberRole(id, userId, role);
       await qc.invalidateQueries({ queryKey: ["team", id] });
+      await qc.invalidateQueries({ queryKey: ["team-members", id] });
       showMsg("success", t("teams.roleUpdated"));
     } catch (err) {
       showMsg(
@@ -344,6 +345,7 @@ export function TeamDetail() {
     try {
       await api.removeTeamMember(id, userId);
       await qc.invalidateQueries({ queryKey: ["team", id] });
+      await qc.invalidateQueries({ queryKey: ["team-members", id] });
       showMsg("success", t("teams.memberRemoved"));
     } catch (err) {
       showMsg(
@@ -358,6 +360,7 @@ export function TeamDetail() {
     try {
       await api.transferOwnership(id, userId);
       await qc.invalidateQueries({ queryKey: ["team", id] });
+      await qc.invalidateQueries({ queryKey: ["team-members", id] });
       showMsg("success", t("teams.ownershipTransferred"));
     } catch (err) {
       showMsg(

--- a/worker/routes/admin.ts
+++ b/worker/routes/admin.ts
@@ -977,9 +977,9 @@ app.patch("/users/:id", async (c) => {
     email_verified?: boolean;
   }>();
 
-  const user = await c.env.DB.prepare("SELECT id FROM users WHERE id = ?")
+  const user = await c.env.DB.prepare("SELECT id, username FROM users WHERE id = ?")
     .bind(id)
-    .first();
+    .first<{ id: string; username: string }>();
   if (!user) return c.json({ error: "User not found" }, 404);
 
   if (body.role === "user" && id === admin.id) {
@@ -1023,6 +1023,7 @@ app.patch("/users/:id", async (c) => {
     body,
     getIp(c),
     c.executionCtx,
+    { resourceName: user.username },
   );
   return c.json({ message: "User updated" });
 });
@@ -1075,6 +1076,7 @@ app.delete("/users/:id", async (c) => {
     {},
     getIp(c),
     c.executionCtx,
+    { resourceName: user.username },
   );
   return c.json({ message: "User deleted" });
 });
@@ -1163,9 +1165,9 @@ app.patch("/apps/:id", async (c) => {
     is_first_party?: boolean;
   }>();
 
-  const app = await c.env.DB.prepare("SELECT id FROM oauth_apps WHERE id = ?")
+  const app = await c.env.DB.prepare("SELECT id, name FROM oauth_apps WHERE id = ?")
     .bind(id)
-    .first();
+    .first<{ id: string; name: string }>();
   if (!app) return c.json({ error: "App not found" }, 404);
 
   const updates: string[] = [];
@@ -1196,11 +1198,12 @@ app.patch("/apps/:id", async (c) => {
     c.env,
     admin.id,
     "admin.app.update",
-    "oauth_app",
+    "app",
     id,
     body,
     getIp(c),
     c.executionCtx,
+    { resourceName: app.name },
   );
   return c.json({ message: "App updated" });
 });
@@ -1825,6 +1828,22 @@ app.delete("/image-proxy/:id", async (c) => {
 
 // ─── Migrate recovery codes to hashed format ──────────────────────────────────
 
+app.get("/migrate-recovery-codes-status", async (c) => {
+  const rows = await c.env.DB.prepare(
+    "SELECT backup_codes FROM user_totp_recovery",
+  ).all<{ backup_codes: string }>();
+
+  let total = 0;
+  let unmigrated = 0;
+  for (const row of rows.results) {
+    total++;
+    const codes = JSON.parse(row.backup_codes) as string[];
+    if (!codes.every((c) => c.startsWith("$sha256$"))) unmigrated++;
+  }
+
+  return c.json({ total, unmigrated });
+});
+
 app.post("/migrate-recovery-codes", async (c) => {
   const rows = await c.env.DB.prepare(
     "SELECT user_id, backup_codes FROM user_totp_recovery",
@@ -1943,6 +1962,7 @@ app.delete("/teams/:id", async (c) => {
     {},
     getIp(c),
     c.executionCtx,
+    { resourceName: team.name },
   );
   return c.json({ message: "Team deleted" });
 });
@@ -2085,6 +2105,11 @@ app.post("/teams/:id/dissolve/cancel", async (c) => {
   const admin = c.get("user");
   const id = c.req.param("id");
 
+  const team = await c.env.DB.prepare("SELECT id, name FROM teams WHERE id = ?")
+    .bind(id)
+    .first<{ id: string; name: string }>();
+  if (!team) return c.json({ error: "Team not found" }, 404);
+
   const now = Math.floor(Date.now() / 1000);
   await c.env.DB.batch([
     c.env.DB.prepare(
@@ -2104,6 +2129,7 @@ app.post("/teams/:id/dissolve/cancel", async (c) => {
     {},
     getIp(c),
     c.executionCtx,
+    { resourceName: team.name },
   );
   return c.json({ message: "Dissolution cancelled" });
 });
@@ -2549,6 +2575,7 @@ async function logAudit(
     actorName?: string | null;
     resourceName?: string | null;
     userAgent?: string | null;
+    geo?: string | null;
   },
 ) {
   let actorName = extra?.actorName ?? null;
@@ -2569,6 +2596,7 @@ async function logAudit(
     resourceName: extra?.resourceName ?? null,
     ip,
     userAgent: extra?.userAgent ?? null,
+    geo: extra?.geo ?? null,
     metadata,
   });
 }
@@ -2680,6 +2708,7 @@ app.post("/invites", async (c) => {
     { email: body.email ?? null },
     getIp(c),
     c.executionCtx,
+    { resourceName: body.email ?? null },
   );
 
   return c.json({ invite: { id, token, invite_url: inviteUrl } }, 201);
@@ -2992,6 +3021,7 @@ app.post("/oauth-sources", async (c) => {
     { slug: body.slug, provider: body.provider },
     getIp(c),
     c.executionCtx,
+    { resourceName: body.slug },
   );
   return c.json(
     {
@@ -3012,10 +3042,10 @@ app.patch("/oauth-sources/:id", async (c) => {
   const { id } = c.req.param();
 
   const existing = await c.env.DB.prepare(
-    "SELECT id FROM oauth_sources WHERE id = ?",
+    "SELECT id, slug FROM oauth_sources WHERE id = ?",
   )
     .bind(id)
-    .first();
+    .first<{ id: string; slug: string }>();
   if (!existing) return c.json({ error: "Source not found" }, 404);
 
   const body = await c.req.json<{
@@ -3109,6 +3139,7 @@ app.patch("/oauth-sources/:id", async (c) => {
     {},
     getIp(c),
     c.executionCtx,
+    { resourceName: existing.slug },
   );
   return c.json({ message: "Updated" });
 });
@@ -3136,6 +3167,7 @@ app.delete("/oauth-sources/:id", async (c) => {
     { slug: existing.slug },
     getIp(c),
     c.executionCtx,
+    { resourceName: existing.slug },
   );
   return c.json({ message: "Deleted" });
 });

--- a/worker/routes/admin.ts
+++ b/worker/routes/admin.ts
@@ -1837,8 +1837,12 @@ app.get("/migrate-recovery-codes-status", async (c) => {
   let unmigrated = 0;
   for (const row of rows.results) {
     total++;
-    const codes = JSON.parse(row.backup_codes) as string[];
-    if (!codes.every((c) => c.startsWith("$sha256$"))) unmigrated++;
+    try {
+      const codes = JSON.parse(row.backup_codes) as string[];
+      if (!codes.every((c) => c.startsWith("$sha256$"))) unmigrated++;
+    } catch {
+      unmigrated++;
+    }
   }
 
   return c.json({ total, unmigrated });

--- a/worker/routes/audit.ts
+++ b/worker/routes/audit.ts
@@ -538,6 +538,27 @@ registerScope("/platform", async (c) => {
 
 // ─── Admin: migrate legacy webhooks into the new audit-webhook system ──────────
 
+app.get("/platform/legacy-webhooks-status", async (c) => {
+  const user = c.get("user");
+  if (user.role !== "admin") return c.json({ error: "Forbidden" }, 403);
+
+  const { results } = await c.env.DB.prepare(
+    "SELECT id, name, user_id FROM webhooks",
+  ).all<{ id: string; name: string; user_id: string | null }>();
+
+  let unmigrated = 0;
+  for (const wh of results) {
+    const existing = await c.env.DB.prepare(
+      "SELECT id FROM audit_webhooks WHERE created_by = ? AND name = ? LIMIT 1",
+    )
+      .bind(user.id, `${wh.name} (migrated)`)
+      .first();
+    if (!existing) unmigrated++;
+  }
+
+  return c.json({ total: results.length, unmigrated });
+});
+
 app.post("/platform/migrate-legacy-webhooks", async (c) => {
   const user = c.get("user");
   if (user.role !== "admin") return c.json({ error: "Forbidden" }, 403);

--- a/worker/routes/audit.ts
+++ b/worker/routes/audit.ts
@@ -543,20 +543,17 @@ app.get("/platform/legacy-webhooks-status", async (c) => {
   if (user.role !== "admin") return c.json({ error: "Forbidden" }, 403);
 
   const { results } = await c.env.DB.prepare(
-    "SELECT id, name, user_id FROM webhooks",
-  ).all<{ id: string; name: string; user_id: string | null }>();
+    `SELECT w.id, w.name, w.user_id,
+            (SELECT 1 FROM audit_webhooks aw WHERE aw.created_by = ? AND aw.name = w.name || ' (migrated)' LIMIT 1) AS migrated
+     FROM webhooks w`,
+  )
+    .bind(user.id)
+    .all<{ id: string; name: string; user_id: string | null; migrated: number | null }>();
 
-  let unmigrated = 0;
-  for (const wh of results) {
-    const existing = await c.env.DB.prepare(
-      "SELECT id FROM audit_webhooks WHERE created_by = ? AND name = ? LIMIT 1",
-    )
-      .bind(user.id, `${wh.name} (migrated)`)
-      .first();
-    if (!existing) unmigrated++;
-  }
+  const total = results.length;
+  const unmigrated = results.filter((r) => !r.migrated).length;
 
-  return c.json({ total: results.length, unmigrated });
+  return c.json({ total, unmigrated });
 });
 
 app.post("/platform/migrate-legacy-webhooks", async (c) => {

--- a/worker/routes/user.ts
+++ b/worker/routes/user.ts
@@ -365,9 +365,9 @@ app.patch("/me", async (c) => {
     changedFields.avatar_url = body.avatar_url ?? "";
 
   const auditMeta = auditRequestMeta(c);
-  const changedFieldNames = updates
-    .filter((u) => u !== "updated_at = ?" && u !== "profile_readme_updated_at = ?" && u !== "profile_readme_source_meta = ?")
-    .map((u) => u.split(" = ")[0]);
+  const changedFieldNames = Object.keys(changedFields).filter(
+    (f) => f !== "updated_at" && f !== "profile_readme_updated_at" && f !== "profile_readme_source_meta"
+  );
   await recordAudit(c.env, c.executionCtx, {
     scope: "user",
     scopeId: user.id,

--- a/worker/routes/user.ts
+++ b/worker/routes/user.ts
@@ -365,6 +365,9 @@ app.patch("/me", async (c) => {
     changedFields.avatar_url = body.avatar_url ?? "";
 
   const auditMeta = auditRequestMeta(c);
+  const changedFieldNames = updates
+    .filter((u) => u !== "updated_at = ?" && u !== "profile_readme_updated_at = ?" && u !== "profile_readme_source_meta = ?")
+    .map((u) => u.split(" = ")[0]);
   await recordAudit(c.env, c.executionCtx, {
     scope: "user",
     scopeId: user.id,
@@ -376,7 +379,8 @@ app.patch("/me", async (c) => {
     resourceName: `@${user.username}`,
     ip: auditMeta.ip,
     userAgent: auditMeta.userAgent,
-    metadata: { changed_fields: Object.keys(changedFields) },
+    geo: auditMeta.geo,
+    metadata: { changed_fields: changedFieldNames },
   });
   c.executionCtx.waitUntil(
     deliverUserEmailNotifications(


### PR DESCRIPTION
修复以下问题：

1. 团队成员列表在角色变更/移除/转让后未同步刷新
2. 审计日志元信息补全（user.profile.update 等），添加 geo 字段
3. 设置 → 危险区域的迁移按钮在无可迁移项时显示为灰色
4. 审计日志资源显示格式统一为 type / id
5. 中文文案统一使用「审计」

## Summary by Sourcery

改进审计日志的元数据、资源命名和迁移体验，并修复角色相关变更后团队成员列表未刷新的问题。

新功能：
- 暴露管理员端点，用于报告恢复代码和旧版 Webhook 的迁移状态，并在管理员 UI 中展示这些状态。

错误修复：
- 确保在角色变更、成员移除或所有权转移操作后，团队成员列表能够刷新。

增强改进：
- 在针对各种管理员和用户操作的审计日志条目中加入资源名称和地理信息。
- 当没有资源名称时，将审计日志中资源的显示格式统一为 `type / id`。
- 在没有剩余项目需要迁移时，禁用危险区域中的迁移按钮。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve audit logging metadata, resource naming, and migration UX, and fix team member list refresh after role-related changes.

New Features:
- Expose admin endpoints to report migration status for recovery codes and legacy webhooks, and surface these statuses in the admin UI.

Bug Fixes:
- Ensure team member lists are refreshed after role change, member removal, or ownership transfer actions.

Enhancements:
- Include resource names and geo information in audit log entries for various admin and user actions.
- Standardize audit log resource display format to `type / id` when no resource name is present.
- Disable dangerous-area migration buttons when there are no remaining items to migrate.

</details>