### PR TITLE
fix: security hardening

### DIFF
--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -298,6 +298,12 @@ grant_type=refresh_token
 &client_secret=<CLIENT_SECRET>
 ```
 
+The response carries a **new** `refresh_token`; store it in place of the one
+you sent. Refresh tokens rotate on every use, and presenting a superseded one
+revokes the whole grant — whether it was replayed by a client that kept the
+old value or by someone who stole it, the safe reading is the same. The new
+token inherits the original expiry: rotating does not extend the grant.
+
 ## Token introspection (RFC 7662)
 
 For server-to-server verification without parsing JWTs:
@@ -309,6 +315,9 @@ Authorization: Basic <base64(client_id:client_secret)>
 
 token=<ACCESS_TOKEN>
 ```
+
+Client credentials are required, and a client can only introspect tokens that
+were issued to it — anything else answers `{"active": false}`.
 
 ### Response (active token)
 
@@ -333,6 +342,9 @@ token=<ACCESS_OR_REFRESH_TOKEN>
 &client_id=<CLIENT_ID>
 &client_secret=<CLIENT_SECRET>
 ```
+
+Client credentials are required, and only the calling client's own tokens are
+revoked. A superseded refresh token revokes the grant it belonged to.
 
 ## ID token
 

--- a/docs/zh/oauth.md
+++ b/docs/zh/oauth.md
@@ -256,6 +256,11 @@ grant_type=refresh_token
 &client_secret=<CLIENT_SECRET>
 ```
 
+响应中会返回**新的** `refresh_token`，请用它替换原有的令牌。刷新令牌每次使用后
+都会轮换，出示已被替换的旧令牌会导致整个授权被撤销——无论是客户端保留了旧值，
+还是令牌遭到窃取，处理方式都一样。新令牌沿用原有的过期时间，轮换不会延长授权
+有效期。
+
 ## 令牌内省（RFC 7662）
 
 用于服务端间验证，无需解析 JWT：
@@ -267,6 +272,9 @@ Authorization: Basic <base64(client_id:client_secret)>
 
 token=<ACCESS_TOKEN>
 ```
+
+必须提供客户端凭据，且客户端只能内省签发给自己的令牌，其他令牌一律返回
+`{"active": false}`。
 
 ### 响应（有效令牌）
 
@@ -291,6 +299,9 @@ token=<ACCESS_OR_REFRESH_TOKEN>
 &client_id=<CLIENT_ID>
 &client_secret=<CLIENT_SECRET>
 ```
+
+必须提供客户端凭据，且只会撤销该客户端自己的令牌。出示已被替换的刷新令牌会撤销
+它所属的整个授权。
 
 ## ID 令牌
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -423,10 +423,17 @@ export const api = {
       "/auth/gpg-challenge",
       { identifier },
     ),
-  gpgLogin: (identifier: string, signed_message: string) =>
-    request<{ token: string; user: UserProfile }>("POST", "/auth/gpg-login", {
+  /** Returns `{ totp_required: true }` instead of a session when the account
+   *  has 2FA enabled — resubmit the same signed message with `totp_code`. */
+  gpgLogin: (identifier: string, signed_message: string, totp_code?: string) =>
+    request<{
+      token?: string;
+      user?: UserProfile;
+      totp_required?: boolean;
+    }>("POST", "/auth/gpg-login", {
       identifier,
       signed_message,
+      totp_code,
     }),
 
   // ─── Sessions ────────────────────────────────────────────────────────────

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -70,6 +70,8 @@ export function Login() {
   const [password, setPassword] = useState("");
   const [totpCode, setTotpCode] = useState("");
   const [totpRequired, setTotpRequired] = useState(false);
+  // Which sign-in method is waiting on the shared 2FA prompt.
+  const [totpFlow, setTotpFlow] = useState<"password" | "gpg">("password");
   const [captcha, setCaptcha] = useState<CaptchaValue>({});
   const [captchaKey, setCaptchaKey] = useState(0);
   const [error, setError] = useState("");
@@ -114,6 +116,12 @@ export function Login() {
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
+    // The 2FA prompt is shared by both sign-in methods — hand the code back
+    // to whichever one asked for it.
+    if (totpRequired && totpFlow === "gpg") {
+      await handleGpgVerify();
+      return;
+    }
     setError("");
     setLoading(true);
     try {
@@ -197,8 +205,19 @@ export function Login() {
     setError("");
     setGpgLoading(true);
     try {
-      const res = await api.gpgLogin(identifier, gpgSignedMessage);
-      setAuth(res.token, res.user);
+      const res = await api.gpgLogin(
+        identifier,
+        gpgSignedMessage,
+        totpRequired ? totpCode : undefined,
+      );
+      if (res.totp_required) {
+        // The account has 2FA: reuse the shared prompt, then come back here
+        // with the code and the same signed message.
+        setTotpFlow("gpg");
+        setTotpRequired(true);
+        return;
+      }
+      if (res.token && res.user) setAuth(res.token, res.user);
     } catch (err) {
       setError(err instanceof ApiError ? err.message : t("auth.gpgFailed"));
     } finally {
@@ -340,6 +359,7 @@ export function Login() {
               appearance="subtle"
               onClick={() => {
                 setTotpRequired(false);
+                setTotpFlow("password");
                 setCaptcha({});
                 setCaptchaKey((v) => v + 1);
               }}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -95,7 +95,17 @@ export function Login() {
   const [gpgPassphrase, setGpgPassphrase] = useState("");
   const [gpgAutoSigning, setGpgAutoSigning] = useState(false);
   const gpgFileRef = useRef<HTMLInputElement>(null);
-  const redirectTo = searchParams.get("redirect") ?? "/";
+  // Only ever bounce to a path on this site. A protocol-relative value like
+  // "//example.com" resolves to another origin, which react-router's history
+  // push falls back to window.location.assign for — an open redirect on a
+  // sign-in page, which is the worst place to have one.
+  const redirectParam = searchParams.get("redirect");
+  const redirectTo =
+    redirectParam &&
+    redirectParam.startsWith("/") &&
+    !redirectParam.startsWith("//")
+      ? redirectParam
+      : "/";
   const errorParam = searchParams.get("error");
   const errorParamMessage = errorParam
     ? t(

--- a/worker/db/migrations/0058_totp_replay_guard.sql
+++ b/worker/db/migrations/0058_totp_replay_guard.sql
@@ -1,0 +1,15 @@
+-- Single-use TOTP codes.
+--
+-- RFC 6238 section 5.2: "The verifier MUST NOT accept the second attempt of
+-- the OTP after the successful validation has been issued for the first OTP."
+-- Verification previously only recomputed the HMAC over the accepted window
+-- (+/- one 30s step), so a code stayed valid for its whole window and could be
+-- replayed by anyone who observed it once — a phishing proxy, a screenshot, a
+-- shoulder-surfer — for up to ~90 seconds, minting as many sessions as it liked.
+--
+-- last_used_counter records the time step of the most recent code this
+-- authenticator accepted. Verification refuses any code whose counter is at or
+-- below it, which retires the used code and every earlier step in the window.
+-- NULL means "never used" — existing authenticators keep working, and the
+-- first successful verification after this migration sets the floor.
+ALTER TABLE totp_authenticators ADD COLUMN last_used_counter INTEGER;

--- a/worker/db/migrations/0059_refresh_token_rotation.sql
+++ b/worker/db/migrations/0059_refresh_token_rotation.sql
@@ -1,0 +1,16 @@
+-- Refresh token rotation with reuse detection.
+--
+-- The refresh grant used to mint a new access token and leave the refresh
+-- token untouched, so a stolen one stayed usable for the whole
+-- refresh_token_ttl_days window (30 by default) with nothing to reveal the
+-- theft. That matters most for public clients: they authenticate with no
+-- secret — correctly, since PKCE binds the code exchange — but PKCE does not
+-- cover the refresh exchange, leaving the refresh token as the only
+-- credential. OAuth 2.0 Security BCP (RFC 9700 section 4.14.2) asks for
+-- rotation with reuse detection or sender constraining.
+--
+-- Each refresh now issues a new token and records the one it replaced here.
+-- Presenting a superseded token is a replay: either the client kept the old
+-- value or someone stole it, and neither is recoverable from, so the whole
+-- token row is revoked and both parties have to start over.
+ALTER TABLE oauth_tokens ADD COLUMN previous_refresh_token TEXT;

--- a/worker/lib/audit.ts
+++ b/worker/lib/audit.ts
@@ -13,7 +13,7 @@
 
 import { randomId } from "./crypto";
 import { decryptSecret } from "./secretCrypto";
-import { loggedFetch } from "./logger";
+import { loggedFetch, loggedSafeFetch } from "./logger";
 import { validateOutboundUrl } from "./safeFetch";
 import { geoJson } from "./geo";
 
@@ -413,7 +413,7 @@ async function deliverDiscord(
       },
     ],
   });
-  const res = await loggedFetch(env, url, {
+  const res = await loggedSafeFetch(env, url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body,
@@ -487,6 +487,6 @@ async function deliverGeneral(
   if (method !== "GET" && method !== "HEAD" && config.body != null) {
     init.body = interpolate(String(config.body), values);
   }
-  const res = await loggedFetch(env, url, init);
+  const res = await loggedSafeFetch(env, url, init);
   return summarizeResponse(res);
 }

--- a/worker/lib/domainOwnership.ts
+++ b/worker/lib/domainOwnership.ts
@@ -2,6 +2,8 @@
 // Each method checks the same token in a different place, so users can pick
 // whichever they have access to: DNS records, a well-known file, or a meta tag.
 
+import { safeFetch } from "./safeFetch";
+
 export const VERIFICATION_METHODS = [
   "dns-txt",
   "http-file",
@@ -39,11 +41,15 @@ export function methodInstructions(
 const FETCH_TIMEOUT_MS = 10_000;
 const HTML_MAX_BYTES = 1 << 20; // 1 MiB
 
+// The domain here is whatever the user claimed. It passed a hostname-shaped
+// regex on the way in, but a name that looks fine can still resolve to a
+// loopback or link-local address, so the fetch goes through safeFetch — which
+// applies that check to the initial URL and to every redirect it follows.
 async function fetchWithTimeout(url: string): Promise<Response | null> {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
   try {
-    return await fetch(url, {
+    return await safeFetch(url, {
       signal: ctrl.signal,
       headers: { "User-Agent": "Prism-Domain-Verify/1.0" },
     });

--- a/worker/lib/imageValidation.ts
+++ b/worker/lib/imageValidation.ts
@@ -3,7 +3,7 @@
 // Returns an error string on failure, null on success.
 // An empty string is treated as "no image" and is always valid.
 
-import { isBlockedHost } from "./safeFetch";
+import { isBlockedHost, safeFetch } from "./safeFetch";
 
 const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
 
@@ -31,7 +31,9 @@ export async function validateImageUrl(url: string): Promise<string | null> {
 
   let res: Response;
   try {
-    res = await fetch(url, { method: "HEAD" });
+    // safeFetch, not fetch: a host that passes the check above can still
+    // redirect the worker onto a blocked one.
+    res = await safeFetch(url, { method: "HEAD" });
   } catch {
     return "Could not reach the image URL";
   }

--- a/worker/lib/logger.ts
+++ b/worker/lib/logger.ts
@@ -8,6 +8,7 @@
 import type { MiddlewareHandler } from "hono";
 import type { Variables } from "../types";
 import { geoJson } from "./geo";
+import { safeFetch } from "./safeFetch";
 
 type AppEnv = { Bindings: Env; Variables: Variables };
 
@@ -170,15 +171,14 @@ async function writeOutboundLog(
     .run();
 }
 
-export async function loggedFetch(
+async function withOutboundLog(
   env: Env,
-  input: RequestInfo | URL,
-  init?: RequestInit,
+  req: Request,
+  run: () => Promise<Response>,
 ): Promise<Response> {
-  const req = new Request(input, init);
   const start = Date.now();
   try {
-    const res = await fetch(req.clone());
+    const res = await run();
     await writeOutboundLog(
       env,
       req,
@@ -193,6 +193,30 @@ export async function loggedFetch(
     );
     throw err;
   }
+}
+
+export async function loggedFetch(
+  env: Env,
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  const req = new Request(input, init);
+  return withOutboundLog(env, req, () => fetch(req.clone()));
+}
+
+/**
+ * loggedFetch for a destination the user chose — a webhook endpoint. The URL
+ * is checked against the SSRF blocklist before the request and again at every
+ * redirect, so an endpoint that validated when it was saved cannot later
+ * bounce the worker somewhere it should not reach.
+ */
+export async function loggedSafeFetch(
+  env: Env,
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const req = new Request(url, init);
+  return withOutboundLog(env, req, () => safeFetch(url, init));
 }
 
 // ─── Module-level KV flag cache (avoids a KV read on every request) ───────────

--- a/worker/lib/logger.ts
+++ b/worker/lib/logger.ts
@@ -43,6 +43,14 @@ const REDACTED_FIELDS = new Set([
   "email_verify_code",
   "email_verify_token",
   "invite_token",
+  // otpauth:// URI — carries the TOTP seed in its query string, so it is as
+  // sensitive as `secret` itself.
+  "uri",
+  // Opaque handles that complete a pending social login / 2FA step. They
+  // arrive as query parameters, which is exactly the position that used to
+  // skip redaction entirely.
+  "key",
+  "state",
   "github_readme_token",
   "github_client_secret",
   "google_client_secret",
@@ -348,7 +356,7 @@ export const requestLogger: MiddlewareHandler<AppEnv> = async (c, next) => {
     details = JSON.stringify({
       req: {
         headers: redactHeaders(c.req.raw.headers),
-        query: Object.fromEntries(parsedUrl.searchParams),
+        query: redactObject(Object.fromEntries(parsedUrl.searchParams)),
         body: parseBody(reqBodyText, reqContentType),
       },
       res: {

--- a/worker/lib/safeFetch.ts
+++ b/worker/lib/safeFetch.ts
@@ -88,3 +88,35 @@ export function isBlockedHost(host: string): boolean {
   if (h.includes(":")) return isBlockedIPv6(h);
   return false;
 }
+
+/**
+ * Fetch a user-supplied URL with the blocklist applied to *every* hop.
+ *
+ * `fetch` follows redirects itself, which quietly defeats the check above:
+ * a host that passes validation can answer 302 and send the worker anywhere
+ * it likes, including the addresses the blocklist exists to keep it away
+ * from. So redirects are handled here instead — each Location is resolved
+ * against the URL it came from and re-validated before the next request.
+ *
+ * Throws when a hop is rejected or the chain runs too long; callers already
+ * treat a thrown fetch as "could not reach the URL".
+ */
+export async function safeFetch(
+  url: string,
+  init: RequestInit = {},
+  maxRedirects = 5,
+): Promise<Response> {
+  let current = url;
+  for (let hop = 0; hop <= maxRedirects; hop++) {
+    const err = validateOutboundUrl(current);
+    if (err) throw new Error(`Blocked URL: ${err}`);
+
+    const res = await fetch(current, { ...init, redirect: "manual" });
+    if (res.status < 300 || res.status > 399) return res;
+
+    const location = res.headers.get("location");
+    if (!location) return res;
+    current = new URL(location, current).toString();
+  }
+  throw new Error("Too many redirects");
+}

--- a/worker/lib/safeFetch.ts
+++ b/worker/lib/safeFetch.ts
@@ -101,22 +101,74 @@ export function isBlockedHost(host: string): boolean {
  * Throws when a hop is rejected or the chain runs too long; callers already
  * treat a thrown fetch as "could not reach the URL".
  */
+/** Credentials that must not travel to a host other than the one they were
+ *  minted for. Authorization and Cookie are what fetch itself drops across an
+ *  origin change; X-Prism-Signature is ours — the HMAC over a webhook body,
+ *  which is addressed to that endpoint and nobody else. */
+const CROSS_ORIGIN_STRIP = [
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+  "x-prism-signature",
+];
+
 export async function safeFetch(
   url: string,
   init: RequestInit = {},
   maxRedirects = 5,
 ): Promise<Response> {
   let current = url;
+  let method = (init.method ?? "GET").toUpperCase();
+  let body = init.body;
+  const headers = new Headers(init.headers as HeadersInit | undefined);
+
   for (let hop = 0; hop <= maxRedirects; hop++) {
     const err = validateOutboundUrl(current);
     if (err) throw new Error(`Blocked URL: ${err}`);
 
-    const res = await fetch(current, { ...init, redirect: "manual" });
+    const res = await fetch(current, {
+      ...init,
+      method,
+      body,
+      headers,
+      redirect: "manual",
+    });
     if (res.status < 300 || res.status > 399) return res;
 
     const location = res.headers.get("location");
     if (!location) return res;
-    current = new URL(location, current).toString();
+
+    // Taking redirects over from fetch means taking on its rules too.
+    // Following one by replaying the original request would re-POST a webhook
+    // payload — and the signature addressed to the first endpoint — at
+    // whatever host the redirect names.
+    const next = new URL(location, current);
+    const crossOrigin = next.origin !== new URL(current).origin;
+
+    if (crossOrigin) {
+      for (const name of CROSS_ORIGIN_STRIP) headers.delete(name);
+    }
+
+    if (
+      res.status === 303 ||
+      (method !== "GET" &&
+        method !== "HEAD" &&
+        (res.status === 301 || res.status === 302))
+    ) {
+      // RFC 9110 §15.4: these turn into a GET, and the body does not travel.
+      method = "GET";
+      body = undefined;
+      headers.delete("content-type");
+      headers.delete("content-length");
+    } else if (body !== undefined && body !== null && crossOrigin) {
+      // 307/308 keep the method and body by definition. Across origins that
+      // is precisely the leak, so refuse rather than deliver it elsewhere.
+      throw new Error(
+        "Refusing to replay a request body across an origin change",
+      );
+    }
+
+    current = next.toString();
   }
   throw new Error("Too many redirects");
 }

--- a/worker/lib/siteInvite.ts
+++ b/worker/lib/siteInvite.ts
@@ -72,13 +72,39 @@ export async function validateSiteInvite(
   return { ok: true, invite };
 }
 
-/** Increment an invite's use_count. Call once, after the user is created. */
-export async function consumeSiteInvite(
+/**
+ * Take one use of an invite, atomically. Returns false when there was none
+ * left to take.
+ *
+ * The cap cannot be enforced by validateSiteInvite's read: concurrent
+ * registrations all see the same use_count, all pass, and all increment —
+ * which on an invite-only instance turns one leaked link into as many
+ * accounts as the attacker can request at once. The condition therefore lives
+ * in the UPDATE, so exactly one racing request can take the last use.
+ *
+ * Claim before inserting the user and release on failure, so a rejected
+ * insert does not burn a use. This mirrors the team-invite registration path.
+ */
+export async function claimSiteInvite(
+  env: Env,
+  invite: SiteInviteRow,
+): Promise<boolean> {
+  const res = await env.DB.prepare(
+    `UPDATE site_invites SET use_count = use_count + 1
+        WHERE id = ? AND (max_uses IS NULL OR use_count < max_uses)`,
+  )
+    .bind(invite.id)
+    .run();
+  return res.meta.changes === 1;
+}
+
+/** Hand back a use taken by claimSiteInvite when the account was not created. */
+export async function releaseSiteInvite(
   env: Env,
   invite: SiteInviteRow,
 ): Promise<void> {
   await env.DB.prepare(
-    "UPDATE site_invites SET use_count = use_count + 1 WHERE id = ?",
+    "UPDATE site_invites SET use_count = use_count - 1 WHERE id = ? AND use_count > 0",
   )
     .bind(invite.id)
     .run();

--- a/worker/lib/totp.ts
+++ b/worker/lib/totp.ts
@@ -81,21 +81,36 @@ export async function generateTotp(
   return code.toString().padStart(6, "0");
 }
 
+/**
+ * Which time step a code matches at, or null when it matches none in the
+ * accepted window. Callers that need single-use semantics record the returned
+ * counter and refuse anything at or below it (see verifyAnyTotp).
+ */
+export async function matchTotpCounter(
+  token: string,
+  secret: string,
+  window = 1,
+  timestampMs = Date.now(),
+): Promise<bigint | null> {
+  const normalized = token.replace(/\s+/g, "");
+  if (normalized.length !== 6 || !/^\d{6}$/.test(normalized)) return null;
+  const secretBytes = base32ToBytes(secret);
+  const counter = BigInt(Math.floor(timestampMs / 30_000));
+  for (let i = -window; i <= window; i++) {
+    const step = counter + BigInt(i);
+    const code = await hotp(secretBytes, step);
+    if (code.toString().padStart(6, "0") === normalized) return step;
+  }
+  return null;
+}
+
 export async function verifyTotp(
   token: string,
   secret: string,
   window = 1,
   timestampMs = Date.now(),
 ): Promise<boolean> {
-  const normalized = token.replace(/\s+/g, "");
-  if (normalized.length !== 6 || !/^\d{6}$/.test(normalized)) return false;
-  const secretBytes = base32ToBytes(secret);
-  const counter = BigInt(Math.floor(timestampMs / 30_000));
-  for (let i = -window; i <= window; i++) {
-    const code = await hotp(secretBytes, counter + BigInt(i));
-    if (code.toString().padStart(6, "0") === normalized) return true;
-  }
-  return false;
+  return (await matchTotpCounter(token, secret, window, timestampMs)) !== null;
 }
 
 export function generateBackupCodes(count = 10): string[] {
@@ -190,12 +205,56 @@ export async function verifyAnyTotp(
       secret: string;
       enabled: number;
       created_at: number;
+      last_used_counter: number | null;
     }>();
   for (const t of totps.results) {
     const plainSecret = (await decryptSecret(env, t.secret)) ?? t.secret;
-    if (await verifyTotp(code, plainSecret)) return true;
+    const counter = await matchTotpCounter(code, plainSecret);
+    if (counter === null) continue;
+    if (!(await claimTotpCounter(db, t.id, counter, t.last_used_counter)))
+      return false;
+    return true;
   }
   return false;
+}
+
+/**
+ * Retire a time step so its code cannot be presented twice (RFC 6238 §5.2).
+ *
+ * Returns false when the step is at or below the last one this authenticator
+ * accepted — a replay of the code just used, or of an earlier code still
+ * inside the window. The UPDATE carries the same condition, so two requests
+ * racing with the same code cannot both win it: whichever lands second
+ * changes no rows and is refused.
+ */
+async function claimTotpCounter(
+  db: D1Database,
+  authenticatorId: string,
+  counter: bigint,
+  lastUsed: number | null,
+): Promise<boolean> {
+  const step = Number(counter);
+  if (lastUsed !== null && step <= lastUsed) return false;
+  const res = await db
+    .prepare(
+      `UPDATE totp_authenticators SET last_used_counter = ?
+        WHERE id = ? AND (last_used_counter IS NULL OR last_used_counter < ?)`,
+    )
+    .bind(step, authenticatorId, step)
+    .run();
+  return res.meta.changes === 1;
+}
+
+/**
+ * Record the step an enrolment code matched at, so the code the user typed to
+ * prove possession cannot then be replayed against the login form.
+ */
+export async function claimEnrolmentCounter(
+  db: D1Database,
+  authenticatorId: string,
+  counter: bigint,
+): Promise<void> {
+  await claimTotpCounter(db, authenticatorId, counter, null);
 }
 
 export function totpUri(secret: string, email: string, issuer: string): string {

--- a/worker/lib/totp.ts
+++ b/worker/lib/totp.ts
@@ -184,13 +184,20 @@ export async function verifyAnyTotp(
     }
     if (idx !== -1) {
       codes.splice(idx, 1);
-      await db
+      // Compare-and-swap against the list this request read. Writing the
+      // whole blob unconditionally loses to concurrency twice over: two
+      // logins presenting the same code both find it and both succeed, and
+      // two presenting different codes overwrite each other, leaving one of
+      // them still valid after it was accepted. Whoever writes against a
+      // list that has since changed is refused and the code stays unspent.
+      const claimed = await db
         .prepare(
-          "UPDATE user_totp_recovery SET backup_codes = ? WHERE user_id = ?",
+          `UPDATE user_totp_recovery SET backup_codes = ?
+            WHERE user_id = ? AND backup_codes = ?`,
         )
-        .bind(JSON.stringify(codes), userId)
+        .bind(JSON.stringify(codes), userId, recovery.backup_codes)
         .run();
-      return true;
+      return claimed.meta.changes === 1;
     }
   }
   const totps = await db

--- a/worker/lib/webhooks.ts
+++ b/worker/lib/webhooks.ts
@@ -4,7 +4,7 @@
 // and the app-webhook test endpoints. The former instance-wide "audit" webhook
 // system has been replaced by the scoped audit-log webhooks (see audit.ts).
 
-import { loggedFetch } from "./logger";
+import { loggedSafeFetch } from "./logger";
 
 const DELIVERY_TIMEOUT_MS = 10_000;
 
@@ -42,7 +42,7 @@ export async function deliverOnce(
   let response: string | null;
 
   try {
-    const res = await loggedFetch(env, url, {
+    const res = await loggedSafeFetch(env, url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/worker/routes/assets.ts
+++ b/worker/routes/assets.ts
@@ -14,6 +14,14 @@ app.get("/*", async (c) => {
   obj.writeHttpMetadata(headers);
   headers.set("Cache-Control", "public, max-age=86400");
   headers.set("Access-Control-Allow-Origin", "*");
+  // The stored content type comes from the uploader, so serve these the way
+  // the image proxy does: no sniffing past the declared type, and nothing
+  // the file references may load if a browser renders it as a document.
+  headers.set("X-Content-Type-Options", "nosniff");
+  headers.set(
+    "Content-Security-Policy",
+    "default-src 'none'; style-src 'unsafe-inline'",
+  );
   return new Response(obj.body, { headers });
 });
 

--- a/worker/routes/auth.ts
+++ b/worker/routes/auth.ts
@@ -53,7 +53,11 @@ import {
   notificationActorMetaFromHeaders,
 } from "../lib/notifications";
 import { teamsBlockingDowngrade } from "../lib/teamRequirements";
-import { validateSiteInvite, consumeSiteInvite } from "../lib/siteInvite";
+import {
+  validateSiteInvite,
+  claimSiteInvite,
+  releaseSiteInvite,
+} from "../lib/siteInvite";
 import type {
   AuthUser,
   PasskeyRow,
@@ -243,6 +247,12 @@ app.post("/register", async (c) => {
     : null;
   const storedVerifyToken = await hashSecret(c.env, verifyToken);
 
+  // Take the invite use before creating the account, so concurrent
+  // registrations cannot all pass the earlier check and overrun the cap. The
+  // claim is released below if the insert is rejected.
+  if (usedInvite && !(await claimSiteInvite(c.env, usedInvite)))
+    return c.json({ error: "Invite token has reached its usage limit" }, 403);
+
   try {
     await c.env.DB.prepare(
       `INSERT INTO users (id, email, username, password_hash, display_name, role, email_verified, email_verify_token, is_active, created_at, updated_at)
@@ -261,15 +271,11 @@ app.post("/register", async (c) => {
       )
       .run();
   } catch (err) {
+    if (usedInvite) await releaseSiteInvite(c.env, usedInvite);
     const msg = err instanceof Error ? err.message : "";
     if (msg.includes("UNIQUE"))
       return c.json({ error: "Email or username already taken" }, 409);
     throw err;
-  }
-
-  // Mark invite as used
-  if (usedInvite) {
-    await consumeSiteInvite(c.env, usedInvite);
   }
 
   if (verifyToken && config.email_provider !== "none") {

--- a/worker/routes/auth.ts
+++ b/worker/routes/auth.ts
@@ -45,7 +45,7 @@ import {
 import { verifyClearsign } from "../lib/gpg";
 import { verifyCaptchaToken } from "../middleware/captcha";
 import { issuePowChallenge } from "../lib/pow";
-import { rateLimitIp } from "../middleware/rateLimit";
+import { rateLimit, rateLimitIp } from "../middleware/rateLimit";
 import { requireAuth } from "../middleware/auth";
 import { proxyImageUrl } from "../lib/proxyImage";
 import {
@@ -377,6 +377,34 @@ app.post("/login", async (c) => {
 
   const isEmail = body.identifier.includes("@");
   const identifier = body.identifier.toLowerCase().trim();
+
+  // Per-account throttle, alongside the per-IP one above. The IP limit alone
+  // bounds nothing for an attacker spread across many addresses, which is the
+  // shape both password spraying and TOTP guessing take. Keyed on the
+  // identifier as typed rather than on a resolved user id, so an unknown
+  // account throttles exactly like a real one and the 429 reveals nothing
+  // about who exists.
+  const idRl = await rateLimit(
+    c.env.KV_SESSIONS,
+    `login-id:${await sha256(identifier)}`,
+    10,
+    300,
+  );
+  if (!idRl.allowed) {
+    c.executionCtx.waitUntil(
+      logLoginError(
+        c.env.DB,
+        "rate_limited",
+        body.identifier ?? null,
+        ip,
+        ua,
+        geoJson(c),
+        {},
+      ).catch(() => {}),
+    );
+    return c.json({ error: "Too many requests" }, 429);
+  }
+
   let user: UserRow | null;
   if (isEmail) {
     // Check primary email first, then alternate emails. kind='user' filter

--- a/worker/routes/auth.ts
+++ b/worker/routes/auth.ts
@@ -27,12 +27,13 @@ import {
 } from "../lib/secretCrypto";
 import { signJWT } from "../lib/jwt";
 import {
+  claimEnrolmentCounter,
   generateBackupCodes,
   generateTotpSecret,
   hashBackupCodes,
+  matchTotpCounter,
   totpUri,
   verifyAnyTotp,
-  verifyTotp,
 } from "../lib/totp";
 import {
   beginPasskeyAuthentication,
@@ -811,14 +812,17 @@ app.post("/totp/verify", requireAuth, async (c) => {
   if (auth.enabled) return c.json({ error: "Already enabled" }, 409);
 
   const plainSecret = (await decryptSecret(c.env, auth.secret)) ?? auth.secret;
-  const ok = await verifyTotp(body.code, plainSecret);
-  if (!ok) return c.json({ error: "Invalid TOTP code" }, 400);
+  const counter = await matchTotpCounter(body.code, plainSecret);
+  if (counter === null) return c.json({ error: "Invalid TOTP code" }, 400);
 
   await c.env.DB.prepare(
     "UPDATE totp_authenticators SET enabled = 1 WHERE id = ?",
   )
     .bind(body.id)
     .run();
+  // Retire the enrolment code too — otherwise the code the user just typed
+  // here is still live at the login form for the rest of its window.
+  await claimEnrolmentCounter(c.env.DB, body.id, counter);
 
   c.executionCtx.waitUntil(
     deliverUserEmailNotifications(

--- a/worker/routes/auth.ts
+++ b/worker/routes/auth.ts
@@ -1552,6 +1552,7 @@ app.post("/gpg-login", async (c) => {
   const body = await c.req.json<{
     identifier: string;
     signed_message: string;
+    totp_code?: string;
   }>();
   if (!body.identifier?.trim() || !body.signed_message?.trim())
     return c.json({ error: "identifier and signed_message are required" }, 400);
@@ -1671,6 +1672,35 @@ app.post("/gpg-login", async (c) => {
       ).catch(() => {}),
     );
     return c.json({ error: "Challenge expired or invalid" }, 401);
+  }
+
+  // Same 2FA gate the password flow applies. A GPG key is a possession
+  // factor, not a second one: without this, an account that enabled TOTP
+  // could still be entered with the key alone, which is not what enabling it
+  // promises. Checked before the challenge is consumed so the client can
+  // resubmit the signed message with a code instead of signing again.
+  const gpgTotpCount = await c.env.DB.prepare(
+    "SELECT COUNT(*) AS n FROM totp_authenticators WHERE user_id = ? AND enabled = 1",
+  )
+    .bind(user.id)
+    .first<{ n: number }>();
+  if ((gpgTotpCount?.n ?? 0) > 0) {
+    if (!body.totp_code)
+      return c.json({ error: "TOTP code required", totp_required: true }, 200);
+    if (!(await verifyAnyTotp(c.env, user.id, body.totp_code))) {
+      c.executionCtx.waitUntil(
+        logLoginError(
+          c.env.DB,
+          "totp_invalid",
+          body.identifier,
+          ip,
+          ua,
+          geoJson(c),
+          { user_id: user.id },
+        ).catch(() => {}),
+      );
+      return c.json({ error: "Invalid TOTP code" }, 401);
+    }
   }
 
   // Consume the challenge (one-time use)

--- a/worker/routes/auth.ts
+++ b/worker/routes/auth.ts
@@ -1161,6 +1161,10 @@ app.post("/passkey/auth/finish", async (c) => {
   const stored = await c.env.KV_CACHE.get(`passkey:auth:${body.challenge}`);
   if (!stored) return c.json({ error: "Authentication session expired" }, 400);
 
+  // Spend the challenge up front rather than on success only: a failed
+  // attempt otherwise leaves it usable for the rest of its TTL.
+  await c.env.KV_CACHE.delete(`passkey:auth:${body.challenge}`);
+
   const options = JSON.parse(stored) as { challenge: string };
 
   // Find passkey by credential id
@@ -1189,8 +1193,6 @@ app.post("/passkey/auth/finish", async (c) => {
 
   if (!verification.verified)
     return c.json({ error: "Verification failed" }, 400);
-
-  await c.env.KV_CACHE.delete(`passkey:auth:${body.challenge}`);
 
   // Update counter
   const now = Math.floor(Date.now() / 1000);

--- a/worker/routes/auth.ts
+++ b/worker/routes/auth.ts
@@ -849,14 +849,17 @@ app.post("/totp/verify", requireAuth, async (c) => {
   const counter = await matchTotpCounter(body.code, plainSecret);
   if (counter === null) return c.json({ error: "Invalid TOTP code" }, 400);
 
+  // Retire the enrolment code before enabling anything - otherwise a failure
+  // between the two leaves 2FA on with the code the user just typed still live
+  // at the login form. Claiming first can only ever leave a counter recorded
+  // against an authenticator that was never enabled, which costs nothing.
+  await claimEnrolmentCounter(c.env.DB, body.id, counter);
+
   await c.env.DB.prepare(
     "UPDATE totp_authenticators SET enabled = 1 WHERE id = ?",
   )
     .bind(body.id)
     .run();
-  // Retire the enrolment code too — otherwise the code the user just typed
-  // here is still live at the login form for the rest of its window.
-  await claimEnrolmentCounter(c.env.DB, body.id, counter);
 
   c.executionCtx.waitUntil(
     deliverUserEmailNotifications(

--- a/worker/routes/connections.ts
+++ b/worker/routes/connections.ts
@@ -12,7 +12,11 @@ import { getConfig, getJwtSecret } from "../lib/config";
 import { getIp } from "../lib/clientIp";
 import { geoJson, recordSessionIp } from "../lib/geo";
 import { decryptSecret, encryptSecret } from "../lib/secretCrypto";
-import { validateSiteInvite, consumeSiteInvite } from "../lib/siteInvite";
+import {
+  validateSiteInvite,
+  claimSiteInvite,
+  releaseSiteInvite,
+} from "../lib/siteInvite";
 import { requireAuth, optionalAuth } from "../middleware/auth";
 import { signJWT } from "../lib/jwt";
 import { setSessionCookie } from "../lib/cookies";
@@ -1217,20 +1221,30 @@ app.post("/complete", async (c) => {
     // `1` here would let an attacker who set victim@example.com on a
     // fresh, unverified Discord account claim that address on Prism.
     const trustedEmail = state.providerEmail;
-    await c.env.DB.prepare(
-      `INSERT INTO users (id, email, username, display_name, role, email_verified, is_active, created_at, updated_at)
-       VALUES (?, ?, ?, ?, 'user', ?, 1, ?, ?)`,
-    )
-      .bind(
-        newUserId,
-        trustedEmail ?? `${state.provider}_${state.providerUserId}@prism.local`,
-        username,
-        display_name,
-        trustedEmail ? 1 : 0,
-        now,
-        now,
+    // Take the invite use before the insert — see claimSiteInvite. Released
+    // below if creating the account fails.
+    if (usedInvite && !(await claimSiteInvite(c.env, usedInvite)))
+      return c.json({ error: "Invite token has reached its usage limit" }, 403);
+    try {
+      await c.env.DB.prepare(
+        `INSERT INTO users (id, email, username, display_name, role, email_verified, is_active, created_at, updated_at)
+         VALUES (?, ?, ?, ?, 'user', ?, 1, ?, ?)`,
       )
-      .run();
+        .bind(
+          newUserId,
+          trustedEmail ??
+            `${state.provider}_${state.providerUserId}@prism.local`,
+          username,
+          display_name,
+          trustedEmail ? 1 : 0,
+          now,
+          now,
+        )
+        .run();
+    } catch (err) {
+      if (usedInvite) await releaseSiteInvite(c.env, usedInvite);
+      throw err;
+    }
 
     const storedAccess = await encryptSecret(c.env, state.accessToken);
     const storedRefresh = await encryptSecret(c.env, state.refreshToken);
@@ -1254,11 +1268,6 @@ app.post("/complete", async (c) => {
       .bind(newUserId)
       .first<UserRow>();
     if (!user) return c.json({ error: "Failed to create user" }, 500);
-
-    // Consume the invite only after the account exists, matching auth.ts.
-    if (usedInvite) {
-      await consumeSiteInvite(c.env, usedInvite);
-    }
 
     return c.json({
       token: await issueJWT(c, user),

--- a/worker/routes/init.ts
+++ b/worker/routes/init.ts
@@ -43,12 +43,21 @@ app.post("/", async (c) => {
   const passwordHash = await hashPassword(body.password);
   const now = Math.floor(Date.now() / 1000);
 
+  // The isInitialized() check above is a fast path, not a guarantee: two
+  // requests arriving together both read "not initialized" and both go on to
+  // create an admin. The INSERT therefore carries the condition itself —
+  // SQLite evaluates the NOT EXISTS as part of the statement, so exactly one
+  // of the racing requests inserts a row and the other sees changes === 0.
+  let created: D1Result;
   try {
-    await c.env.DB.batch([
-      c.env.DB.prepare(
-        `INSERT INTO users (id, email, username, password_hash, display_name, role, email_verified, is_active, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, 'admin', 1, 1, ?, ?)`,
-      ).bind(
+    created = await c.env.DB.prepare(
+      `INSERT INTO users (id, email, username, password_hash, display_name, role, email_verified, is_active, created_at, updated_at)
+       SELECT ?, ?, ?, ?, ?, 'admin', 1, 1, ?, ?
+        WHERE NOT EXISTS (
+          SELECT 1 FROM users WHERE role = 'admin' AND kind = 'user'
+        )`,
+    )
+      .bind(
         userId,
         body.email.toLowerCase().trim(),
         body.username.toLowerCase().trim(),
@@ -56,14 +65,17 @@ app.post("/", async (c) => {
         body.display_name ?? body.username,
         now,
         now,
-      ),
-    ]);
+      )
+      .run();
   } catch (err) {
     const msg = err instanceof Error ? err.message : "";
     if (msg.includes("UNIQUE")) {
       return c.json({ error: "Email or username already taken" }, 409);
     }
     throw err;
+  }
+  if (created.meta.changes !== 1) {
+    return c.json({ error: "Platform already initialized" }, 409);
   }
 
   // Mark initialized and optionally set site name

--- a/worker/routes/oauth.ts
+++ b/worker/routes/oauth.ts
@@ -1951,9 +1951,18 @@ app.post("/token", async (c) => {
 
     // Consume code — match the row we just selected (codeRow.code is
     // already in stored form, so a single direct compare is enough).
-    await c.env.DB.prepare("DELETE FROM oauth_codes WHERE code = ?")
+    //
+    // The delete is what makes the code single-use, so its result decides
+    // whether this request may continue: two redemptions racing here both
+    // pass the checks above, and only the one that actually removes the row
+    // gets to mint tokens.
+    const consumed = await c.env.DB.prepare(
+      "DELETE FROM oauth_codes WHERE code = ?",
+    )
       .bind(codeRow.code)
       .run();
+    if (consumed.meta.changes !== 1)
+      return c.json({ error: "invalid_grant" }, 400);
 
     const user = await c.env.DB.prepare(
       "SELECT * FROM users WHERE id = ? AND kind = 'user'",

--- a/worker/routes/oauth.ts
+++ b/worker/routes/oauth.ts
@@ -2201,9 +2201,39 @@ app.get("/userinfo", async (c) => {
 
 // ─── Token introspection ─────────────────────────────────────────────────────
 
+/**
+ * Authenticate the calling client from HTTP Basic or form parameters, the two
+ * forms the token endpoint already accepts. Returns the app row, or null when
+ * the credentials do not check out.
+ */
+async function authenticateCallingClient(
+  c: Context<AppEnv>,
+  params: Record<string, string>,
+): Promise<OAuthAppRow | null> {
+  const basicAuth = parseBasicAuth(c.req.header("Authorization"));
+  const clientId = basicAuth?.clientId ?? params.client_id;
+  const clientSecret = basicAuth?.clientSecret ?? params.client_secret;
+  if (!clientId) return null;
+  const oauthApp = await c.env.DB.prepare(
+    "SELECT * FROM oauth_apps WHERE client_id = ? AND is_active = 1",
+  )
+    .bind(clientId)
+    .first<OAuthAppRow>();
+  if (!oauthApp) return null;
+  if (!(await clientSecretValid(c.env, oauthApp, clientSecret))) return null;
+  return oauthApp;
+}
+
 app.post("/introspect", async (c) => {
   const body = await c.req.text();
   const params = Object.fromEntries(new URLSearchParams(body));
+
+  // RFC 7662 §2.1: the endpoint has to be authorized. Unauthenticated, it
+  // answers whether any token is live and hands back its scopes, client and
+  // subject — a convenient way to triage tokens picked up somewhere else.
+  const caller = await authenticateCallingClient(c, params);
+  if (!caller) return c.json({ error: "invalid_client" }, 401);
+
   const token = params.token;
   if (!token) return c.json({ active: false });
 
@@ -2235,6 +2265,8 @@ app.post("/introspect", async (c) => {
   }
 
   if (!tokenRow || tokenRow.expires_at < now) return c.json({ active: false });
+  // A client may only introspect what was issued to it.
+  if (tokenRow.client_id !== caller.client_id) return c.json({ active: false });
 
   const scopes = JSON.parse(tokenRow.scopes) as string[];
   return c.json({
@@ -2253,6 +2285,13 @@ app.post("/introspect", async (c) => {
 app.post("/revoke", async (c) => {
   const body = await c.req.text();
   const params = Object.fromEntries(new URLSearchParams(body));
+
+  // RFC 7009 §2.1: authenticate the client, and revoke only what belongs to
+  // it — otherwise anyone who learns a token value can invalidate it, including
+  // one issued to a different client.
+  const caller = await authenticateCallingClient(c, params);
+  if (!caller) return c.json({ error: "invalid_client" }, 401);
+
   const token = params.token;
   if (token) {
     const tokenLookup = await hashLookupCandidate(c.env, token);
@@ -2261,9 +2300,21 @@ app.post("/revoke", async (c) => {
     // accept and no-op.
     if (tokenLookup) {
       await c.env.DB.prepare(
-        "DELETE FROM oauth_tokens WHERE access_token = ? OR access_token = ? OR refresh_token = ? OR refresh_token = ?",
+        `DELETE FROM oauth_tokens
+          WHERE client_id = ?
+            AND (access_token = ? OR access_token = ?
+                 OR refresh_token = ? OR refresh_token = ?
+                 OR previous_refresh_token = ? OR previous_refresh_token = ?)`,
       )
-        .bind(token, tokenLookup, token, tokenLookup)
+        .bind(
+          caller.client_id,
+          token,
+          tokenLookup,
+          token,
+          tokenLookup,
+          token,
+          tokenLookup,
+        )
         .run();
     }
   }

--- a/worker/routes/oauth.ts
+++ b/worker/routes/oauth.ts
@@ -2158,12 +2158,6 @@ app.get("/userinfo", async (c) => {
     c.env.DB,
     c.env.APP_URL,
   );
-  console.log("[OIDC] userinfo response", {
-    sub: user.id,
-    client_id: tokenRow.client_id,
-    scopes,
-    claim_keys: Object.keys(claims),
-  });
   return c.json(claims);
 });
 
@@ -4089,13 +4083,6 @@ async function buildClaims(
       provider_user_id: r.provider_user_id,
     }));
   }
-  console.log("[OIDC] buildClaims", {
-    sub: user.id,
-    client_id: clientId,
-    scopes,
-    oidc_fields: [...oidcFields],
-    claim_keys: Object.keys(claims),
-  });
   return claims;
 }
 
@@ -4115,14 +4102,6 @@ async function buildIdToken(
   claims.iss = issuer;
   claims.aud = clientId;
   if (nonce) claims.nonce = nonce;
-  console.log("[OIDC] issuing ID token", {
-    sub: user.id,
-    client_id: clientId,
-    iss: issuer,
-    scopes,
-    claim_keys: Object.keys(claims),
-    has_nonce: !!nonce,
-  });
   return signIdTokenRS256(claims, privateKey, kid, ttl);
 }
 

--- a/worker/routes/oauth.ts
+++ b/worker/routes/oauth.ts
@@ -2063,7 +2063,24 @@ app.post("/token", async (c) => {
       .bind(refresh_token, refreshLookup)
       .first<OAuthTokenRow>();
 
-    if (!tokenRow || tokenRow.client_id !== clientId)
+    // A token that matches nothing current may still be one this row already
+    // rotated away. That is a replay — the client kept a superseded value, or
+    // someone else is using a stolen one — and there is no way to tell which
+    // from here, so the grant is revoked and both have to re-authorise.
+    if (!tokenRow) {
+      const superseded = await c.env.DB.prepare(
+        "SELECT id FROM oauth_tokens WHERE previous_refresh_token = ? OR previous_refresh_token = ?",
+      )
+        .bind(refresh_token, refreshLookup)
+        .first<{ id: string }>();
+      if (superseded) {
+        await c.env.DB.prepare("DELETE FROM oauth_tokens WHERE id = ?")
+          .bind(superseded.id)
+          .run();
+      }
+      return c.json({ error: "invalid_grant" }, 400);
+    }
+    if (tokenRow.client_id !== clientId)
       return c.json({ error: "invalid_grant" }, 400);
     if (!tokenRow.refresh_expires_at || tokenRow.refresh_expires_at < now) {
       return c.json(
@@ -2105,18 +2122,39 @@ app.post("/token", async (c) => {
     }
 
     const storedNewAccess = await hashSecret(c.env, newAccessToken);
-    await c.env.DB.prepare(
-      "UPDATE oauth_tokens SET access_token = ?, expires_at = ? WHERE id = ?",
+
+    // Rotate the refresh token as well. The row remembers the value being
+    // replaced so a later presentation of it can be recognised as a replay
+    // (see the reuse check above). refresh_expires_at is deliberately left
+    // alone: rotation should not extend the grant's lifetime.
+    const newRefreshToken = randomBase64url(48);
+    const storedNewRefresh = await hashSecret(c.env, newRefreshToken);
+    const rotated = await c.env.DB.prepare(
+      `UPDATE oauth_tokens
+          SET access_token = ?, expires_at = ?,
+              refresh_token = ?, previous_refresh_token = ?
+        WHERE id = ? AND refresh_token = ?`,
     )
-      .bind(storedNewAccess, now + atTtl, tokenRow.id)
+      .bind(
+        storedNewAccess,
+        now + atTtl,
+        storedNewRefresh,
+        tokenRow.refresh_token,
+        tokenRow.id,
+        tokenRow.refresh_token,
+      )
       .run();
+    // Lost a race with a concurrent refresh of the same token: that request
+    // rotated first, so this one is holding a superseded value.
+    if (rotated.meta.changes !== 1)
+      return c.json({ error: "invalid_grant" }, 400);
 
     return c.json({
       access_token: newAccessToken,
       token_type: "Bearer",
       expires_in: atTtl,
       scope: scopes.join(" "),
-      refresh_token,
+      refresh_token: newRefreshToken,
     });
   }
 

--- a/worker/routes/oauth.ts
+++ b/worker/routes/oauth.ts
@@ -2231,8 +2231,15 @@ app.post("/introspect", async (c) => {
   // RFC 7662 §2.1: the endpoint has to be authorized. Unauthenticated, it
   // answers whether any token is live and hands back its scopes, client and
   // subject — a convenient way to triage tokens picked up somewhere else.
+  //
+  // Public clients are refused outright. They authenticate with nothing but a
+  // client_id, which is not secret, so admitting them would leave the oracle
+  // open to anyone who can read an app's public configuration. Introspection
+  // is for confidential resource servers; a public client that wants to know
+  // whether its token still works can simply use it.
   const caller = await authenticateCallingClient(c, params);
-  if (!caller) return c.json({ error: "invalid_client" }, 401);
+  if (!caller || caller.is_public)
+    return c.json({ error: "invalid_client" }, 401);
 
   const token = params.token;
   if (!token) return c.json({ active: false });
@@ -2289,6 +2296,11 @@ app.post("/revoke", async (c) => {
   // RFC 7009 §2.1: authenticate the client, and revoke only what belongs to
   // it — otherwise anyone who learns a token value can invalidate it, including
   // one issued to a different client.
+  //
+  // Public clients are allowed here, unlike introspection: signing out of an
+  // SPA or a mobile app should revoke the token it holds, and the caller has
+  // to present that token anyway. The client_id only narrows the delete to
+  // that app's own grants.
   const caller = await authenticateCallingClient(c, params);
   if (!caller) return c.json({ error: "invalid_client" }, 401);
 

--- a/worker/routes/proxy.ts
+++ b/worker/routes/proxy.ts
@@ -10,7 +10,7 @@
 
 import { Hono } from "hono";
 import type { Variables } from "../types";
-import { isBlockedHost } from "../lib/safeFetch";
+import { isBlockedHost, safeFetch } from "../lib/safeFetch";
 import { registerImageProxyMapping } from "../lib/proxyImage";
 import { requireAuth } from "../middleware/auth";
 
@@ -134,12 +134,15 @@ app.get("/:id", async (c) => {
 
   let upstream: Response;
   try {
-    upstream = await fetch(rawUrl, {
+    // safeFetch re-applies the host check to every redirect hop. Without it
+    // the mapping's host is checked once here and the upstream is free to
+    // bounce the worker onto a blocked address afterwards.
+    upstream = await safeFetch(rawUrl, {
       method: "GET",
       headers: { Accept: "image/*" },
       // Ask Cloudflare to cache the upstream response
       cf: { cacheTtl: 3600, cacheEverything: true },
-    });
+    } as RequestInit);
   } catch {
     return c.json({ error: "Could not reach upstream URL" }, 502);
   }

--- a/worker/routes/user.ts
+++ b/worker/routes/user.ts
@@ -607,20 +607,6 @@ app.post("/me/readme/sync", async (c) => {
   );
 });
 
-// Serve R2 assets
-app.get("/assets/*", async (c) => {
-  if (!c.env.R2_ASSETS) return c.json({ error: "Not found" }, 404);
-  const r2 = c.env.R2_ASSETS;
-  const key = c.req.path.replace("/api/assets/", "");
-  const obj = await r2.get(key);
-  if (!obj) return c.json({ error: "Not found" }, 404);
-
-  const headers = new Headers();
-  obj.writeHttpMetadata(headers);
-  headers.set("Cache-Control", "public, max-age=86400");
-  return new Response(obj.body, { headers });
-});
-
 // Delete account
 app.delete("/me", async (c) => {
   const user = c.get("user");

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -289,6 +289,9 @@ export interface OAuthTokenRow {
   id: string;
   access_token: string;
   refresh_token: string | null;
+  /** The refresh token this row last rotated away, so presenting it again can
+   *  be recognised as a replay. Stored in the same hashed form. */
+  previous_refresh_token: string | null;
   client_id: string;
   user_id: string;
   scopes: string; // JSON string[]


### PR DESCRIPTION
## Sourcery 总结

加强身份验证、OAuth 令牌处理、出站请求、日志记录和用户控制内容，以防范重放、滥用、信息泄露和 SSRF 风险。

新功能：
- 应用刷新令牌轮换机制并检测令牌重用，同时保留授权的原始过期时间。
- 要求对 OAuth 客户端进行身份验证，并在令牌内省和撤销时检查所有权。
- 将双因素身份验证扩展至 GPG 登录，并加入一次性 TOTP 和备用代码保护。

错误修复：
- 防止登录页面中的开放重定向，并强制以原子方式限制站点邀请的使用次数。
- 阻止用户控制的出站请求通过重定向发起 SSRF，并保护存储的资源免受内容嗅探和主动内容攻击。
- 防止 OAuth 授权码和通行密钥质询被重放，并解决并发初始化竞争问题。

增强功能：
- 添加基于标识符的登录限流，并从日志中隐藏敏感查询参数和出站身份验证数据。
- 移除敏感的 OIDC 诊断日志，并加强 webhook、域名验证、图片代理和资源交付路径的安全性。

文档：
- 在中文和英文 OAuth 指南中记录刷新令牌轮换、令牌内省授权和客户端范围的撤销。

维护工作：
- 添加支持一次性 TOTP 验证和刷新令牌重用检测的数据库字段。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

加强身份验证、OAuth 流程、出站请求和用户控制的内容，防范重放、滥用、信息泄露和 SSRF 风险。

新功能：
- 将双因素身份验证扩展至 GPG 登录，支持一次性 TOTP 和备份代码保护。
- 轮换 OAuth 刷新令牌并检测令牌复用，同时保留授权的原始过期时间。
- 要求对 OAuth 客户端进行身份验证和所有权检查，以执行令牌内省和撤销操作。

错误修复：
- 防止登录页面发生开放重定向，并以原子方式强制执行站点邀请使用次数限制。
- 防止重放 OAuth 授权码、Passkey 挑战和已接受的 TOTP 代码。
- 阻止通过重定向的出站请求发起 SSRF，并保护存储的资源免受内容嗅探和主动内容执行的影响。

增强功能：
- 添加基于标识符的登录速率限制，并从日志中删去敏感查询参数、出站凭据和 OIDC 诊断信息。
- 加强 Webhook 传递、域名验证、图片代理以及其他用户控制资源的获取流程。

文档：
- 在英文和中文 OAuth 指南中记录刷新令牌轮换、内省授权和撤销所有权相关内容。

杂项：
- 添加用于跟踪 TOTP 重放和检测刷新令牌复用的数据库字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden authentication, OAuth flows, outbound requests, and user-controlled content against replay, abuse, information disclosure, and SSRF risks.

New Features:
- Extend two-factor authentication to GPG login with single-use TOTP and backup-code protection.
- Rotate OAuth refresh tokens with reuse detection while preserving the grant's original expiry.
- Require OAuth client authentication and ownership checks for token introspection and revocation.

Bug Fixes:
- Prevent open redirects from the login page and enforce site-invite usage limits atomically.
- Prevent replay of OAuth authorization codes, passkey challenges, and accepted TOTP codes.
- Block SSRF through redirected outbound requests and protect stored assets from content sniffing and active content execution.

Enhancements:
- Add identifier-based login rate limiting and redact sensitive query parameters, outbound credentials, and OIDC diagnostics from logs.
- Harden webhook delivery, domain verification, image proxying, and other user-controlled resource fetches.

Documentation:
- Document refresh-token rotation, introspection authorization, and revocation ownership in the English and Chinese OAuth guides.

Chores:
- Add database fields for TOTP replay tracking and refresh-token reuse detection.

</details>

</details>