### PR TITLE
feat(connections): add Cloudflare as a built-in OAuth source

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A self-hosted OAuth 2.0 / OpenID Connect identity platform built on Cloudflare W
 
 - **OAuth 2.0 + OpenID Connect** — authorization code + PKCE, RS256 ID tokens, introspection / revocation, UserInfo, Discovery, JWKS
 - **Step-up 2FA** — server-initiated, action-pinned re-confirmation with sudo grace windows for sensitive operations
-- **Social & federated login** — GitHub, Google, Microsoft, Discord, Telegram, X, Generic OIDC, Generic OAuth 2 — multiple sources of the same type
+- **Social & federated login** — GitHub, Google, Microsoft, Discord, Telegram, X, Cloudflare, Generic OIDC, Generic OAuth 2 — multiple sources of the same type
 - **Multi-factor auth** — multiple TOTP authenticators per account, passkeys (WebAuthn), GPG keys (incl. ML-DSA), backup codes
 - **Teams** — shared ownership of OAuth apps and domains, roles, invites, transfer-ownership, site-floor join requirements
 - **App registry** — users register and manage their own OAuth apps; admins can verify; cross-app permission scopes

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 - **OAuth 2.0 + OpenID Connect** — 授权码 + PKCE、RS256 ID Token、令牌内省 / 撤销、UserInfo、Discovery、JWKS
 - **步骤提升 2FA** — 服务端发起、行动钉死的二次确认；为高风险操作提供 sudo 宽限期
-- **社交与联邦登录** — GitHub、Google、Microsoft、Discord、Telegram、X，Generic OIDC、Generic OAuth 2 — 同一类型可多源
+- **社交与联邦登录** — GitHub、Google、Microsoft、Discord、Telegram、X、Cloudflare，Generic OIDC、Generic OAuth 2 — 同一类型可多源
 - **多因素认证** — 单账号多 TOTP 认证器、Passkey（WebAuthn）、GPG 公钥（含 ML-DSA）、备用码
 - **团队** — OAuth 应用与域名的共享所有权；角色、邀请、所有权转移、站点级加入门槛
 - **应用注册** — 用户自助创建 OAuth 应用；管理员可验证；支持跨应用 scope

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -208,15 +208,15 @@ migration and is idempotent — re-running is safe.
 
 ### Source fields
 
-| Field         | Description                                                                                      |
-| ------------- | ------------------------------------------------------------------------------------------------ |
-| Slug          | Unique URL key — appears in the callback URL as `/api/connections/<slug>/callback`               |
-| Provider      | Base OAuth type (GitHub, Google, Microsoft, Discord, Telegram, X, Generic OIDC, Generic OAuth 2) |
-| Display name  | Label shown on login/register buttons                                                            |
-| Client ID     | OAuth application client ID                                                                      |
-| Client Secret | OAuth application client secret                                                                  |
-| Trusted       | When `true` (default), social login through this source skips email verification                 |
-| Enabled       | Toggle to show/hide the source on login without deleting it                                      |
+| Field         | Description                                                                                                  |
+| ------------- | ------------------------------------------------------------------------------------------------------------ |
+| Slug          | Unique URL key — appears in the callback URL as `/api/connections/<slug>/callback`                           |
+| Provider      | Base OAuth type (GitHub, Google, Microsoft, Discord, Telegram, X, Cloudflare, Generic OIDC, Generic OAuth 2) |
+| Display name  | Label shown on login/register buttons                                                                        |
+| Client ID     | OAuth application client ID                                                                                  |
+| Client Secret | OAuth application client secret                                                                              |
+| Trusted       | When `true` (default), social login through this source skips email verification                             |
+| Enabled       | Toggle to show/hide the source on login without deleting it                                                  |
 
 ### Generic OIDC sources
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,8 +207,8 @@ respects ETag and serves stale-on-error.
 
 ## Social login
 
-Each OAuth source (GitHub, Google, Microsoft, Discord, Telegram, X, Generic OIDC,
-Generic OAuth 2) is now a row in the `oauth_sources` table — managed in
+Each OAuth source (GitHub, Google, Microsoft, Discord, Telegram, X, Cloudflare,
+Generic OIDC, Generic OAuth 2) is now a row in the `oauth_sources` table — managed in
 **Admin → OAuth Sources**, not here. The legacy keys below remain readable for
 backwards compatibility but new deployments should use OAuth Sources directly.
 

--- a/docs/social-login.md
+++ b/docs/social-login.md
@@ -1,6 +1,6 @@
 ---
 title: Social Login Setup
-description: Configure OAuth sources in Prism — built-in providers (GitHub, Google, Microsoft, Discord, Telegram, X) and custom Generic OIDC / OAuth 2.0 providers.
+description: Configure OAuth sources in Prism — built-in providers (GitHub, Google, Microsoft, Discord, Telegram, X, Cloudflare) and custom Generic OIDC / OAuth 2.0 providers.
 ---
 
 # Social Login Setup
@@ -213,6 +213,48 @@ Save. The button appears on the login page immediately.
 - Prism requests `users.read tweet.read offline.access`. `offline.access` is what allows the access token to be refreshed; without it X returns no `refresh_token` and the **Refresh** action on the Connections page will require the user to reconnect.
 - Prism calls `/2/users/me?user.fields=profile_image_url,name,username` and flattens the v2 `data` envelope before storing the profile.
 - The X token endpoint requires HTTP Basic authentication, not `client_secret` in the request body. Prism handles this automatically for both the initial token exchange and refreshes.
+
+### Cloudflare
+
+The Cloudflare dashboard is itself an OpenID Connect provider. **Sign in with Cloudflare** lets users authenticate with their Cloudflare account — the same flow that lets tools such as Wrangler act on a user's account. Prism uses Cloudflare's fixed OIDC endpoints (`https://dash.cloudflare.com/oauth2/{auth,token,userinfo}`), so — unlike Generic OIDC — you do **not** enter any endpoint URLs.
+
+#### 1. Create a Cloudflare OAuth client
+
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/oauth-clients), go to **Manage Account → OAuth clients** and select **Create client**.
+2. Fill in the form:
+
+   | Field                       | Value                                                             |
+   | --------------------------- | ----------------------------------------------------------------- |
+   | Client name                 | Your site name                                                    |
+   | Response type               | `code`                                                            |
+   | Grant type                  | `authorization_code` (add `refresh_token` to allow token refresh) |
+   | Token authentication method | **Client secret post** (`client_secret_post`)                     |
+   | Redirect URLs               | `https://your-prism-domain/api/connections/<slug>/callback`       |
+
+3. On the scopes step, keep **`openid`** (required — it is what returns the user's identity). If you enabled the `refresh_token` grant, also keep **`offline_access`**.
+4. Select **Create client** and copy the **Client ID** and **Client Secret** immediately — the secret is only shown once.
+
+#### 2. Add the source in Prism
+
+Go to **Admin → OAuth Sources → Add source**:
+
+| Field         | Value                                |
+| ------------- | ------------------------------------ |
+| Slug          | `cloudflare` (or any unique key)     |
+| Provider      | **Cloudflare**                       |
+| Display name  | `Cloudflare` (shown on login button) |
+| Client ID     | Paste from Cloudflare                |
+| Client Secret | Paste from Cloudflare                |
+
+Save. The button appears on the login page immediately.
+
+#### Notes
+
+- Prism requests `openid offline_access` and maps the OIDC userinfo response with standard claims (`sub` for the provider ID, `name`/`preferred_username`, `picture`).
+- **Email:** Prism trusts a Cloudflare email only when the userinfo response marks it verified (`email_verified`). If Cloudflare returns no verified email for the granted scopes, the user gets a placeholder email (`cloudflare_<id>@prism.local`) and starts unverified — they can add and verify a real email from their profile settings later. This mirrors the Telegram and X flows.
+- **Refresh tokens:** to make the **Refresh** action on the Connections page work, the OAuth client must have the `refresh_token` grant enabled and the source must keep the `offline_access` scope (Prism sends it by default). Without it, Cloudflare returns no `refresh_token` and the user must reconnect to renew access.
+- **Private vs. public clients:** a new OAuth client is **private** — only members of the Cloudflare account that created it can authorize. To let any Cloudflare user sign in, complete Cloudflare's requirements and change the client's visibility to **public** (this is permanent).
+- The token endpoint accepts `client_secret_post`, so no PKCE or HTTP Basic configuration is needed on your side.
 
 ## Generic OpenID Connect
 

--- a/docs/zh/admin.md
+++ b/docs/zh/admin.md
@@ -206,15 +206,15 @@ description: 在 Prism 管理面板中管理用户、应用、OAuth 来源、设
 
 ### 来源字段
 
-| 字段          | 说明                                                                                        |
-| ------------- | ------------------------------------------------------------------------------------------- |
-| Slug          | 唯一 URL 键 — 出现在回调 URL 中，格式为 `/api/connections/<slug>/callback`                  |
-| 提供商        | 基础 OAuth 类型（GitHub、Google、Microsoft、Discord、Telegram、X、通用 OIDC、通用 OAuth 2） |
-| 显示名称      | 显示在登录/注册按钮上的标签                                                                 |
-| Client ID     | OAuth 应用的客户端 ID                                                                       |
-| Client Secret | OAuth 应用的客户端密钥                                                                      |
-| 受信任        | 为 `true`（默认）时，通过该来源的社交登录跳过邮箱验证                                       |
-| 启用          | 切换是否在登录页面显示该来源，禁用不会删除数据                                              |
+| 字段          | 说明                                                                                                    |
+| ------------- | ------------------------------------------------------------------------------------------------------- |
+| Slug          | 唯一 URL 键 — 出现在回调 URL 中，格式为 `/api/connections/<slug>/callback`                              |
+| 提供商        | 基础 OAuth 类型（GitHub、Google、Microsoft、Discord、Telegram、X、Cloudflare、通用 OIDC、通用 OAuth 2） |
+| 显示名称      | 显示在登录/注册按钮上的标签                                                                             |
+| Client ID     | OAuth 应用的客户端 ID                                                                                   |
+| Client Secret | OAuth 应用的客户端密钥                                                                                  |
+| 受信任        | 为 `true`（默认）时，通过该来源的社交登录跳过邮箱验证                                                   |
+| 启用          | 切换是否在登录页面显示该来源，禁用不会删除数据                                                          |
 
 ### 通用 OIDC 来源
 

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -174,7 +174,7 @@ description: 所有存储在 D1 中的运行时配置项，以及 Wrangler 绑�
 
 ## 社交登录
 
-每个 OAuth 源（GitHub、Google、Microsoft、Discord、Telegram、X、Generic OIDC、Generic OAuth 2）都已迁入 `oauth_sources` 表 — 在 **Admin → OAuth Sources** 中管理，不在本页设置。下方的旧字段仍保留以兼容历史数据，新部署应直接使用 OAuth Sources。
+每个 OAuth 源（GitHub、Google、Microsoft、Discord、Telegram、X、Cloudflare、Generic OIDC、Generic OAuth 2）都已迁入 `oauth_sources` 表 — 在 **Admin → OAuth Sources** 中管理，不在本页设置。下方的旧字段仍保留以兼容历史数据，新部署应直接使用 OAuth Sources。
 
 | 键（旧）                  | 说明                                 |
 | ------------------------- | ------------------------------------ |

--- a/docs/zh/social-login.md
+++ b/docs/zh/social-login.md
@@ -1,6 +1,6 @@
 ---
 title: 社交登录配置
-description: 在 Prism 中配置 OAuth 来源——内置提供商（GitHub、Google、Microsoft、Discord、Telegram、X）以及自定义通用 OIDC / OAuth 2.0 提供商。
+description: 在 Prism 中配置 OAuth 来源——内置提供商（GitHub、Google、Microsoft、Discord、Telegram、X、Cloudflare）以及自定义通用 OIDC / OAuth 2.0 提供商。
 ---
 
 # 社交登录配置
@@ -212,6 +212,48 @@ X 采用强制 PKCE 的 OAuth 2.0。Prism 会在每次授权请求中生成并�
 - Prism 请求的 scope 为 `users.read tweet.read offline.access`。其中 `offline.access` 是获取 `refresh_token` 的前提；缺失它时连接页的**刷新**按钮会要求用户重新授权。
 - Prism 调用 `/2/users/me?user.fields=profile_image_url,name,username`，并在写入前展开 v2 的 `data` 外层。
 - X 的令牌端点要求 HTTP Basic 认证，而非在请求体里附带 `client_secret`。Prism 在初次换码和刷新流程中已自动处理。
+
+### Cloudflare
+
+Cloudflare 控制台本身就是一个 OpenID Connect 提供商。**使用 Cloudflare 登录**让用户以其 Cloudflare 账号进行认证——与 Wrangler 等工具代表用户操作账号所用的是同一套流程。Prism 使用 Cloudflare 固定的 OIDC 端点（`https://dash.cloudflare.com/oauth2/{auth,token,userinfo}`），因此与通用 OIDC 不同，你**无需**填写任何端点 URL。
+
+#### 1. 创建 Cloudflare OAuth 客户端
+
+1. 在 [Cloudflare 控制台](https://dash.cloudflare.com/?to=/:account/oauth-clients)，进入 **Manage Account → OAuth clients**，点击 **Create client**。
+2. 填写表单：
+
+   | 字段         | 值                                                           |
+   | ------------ | ------------------------------------------------------------ |
+   | 客户端名称   | 你的站点名称                                                 |
+   | 响应类型     | `code`                                                       |
+   | 授权类型     | `authorization_code`（需要令牌刷新时再加上 `refresh_token`） |
+   | 令牌认证方式 | **Client secret post**（`client_secret_post`）               |
+   | 重定向 URL   | `https://your-prism-domain/api/connections/<slug>/callback`  |
+
+3. 在权限范围步骤，保留 **`openid`**（必需——它负责返回用户身份）。若启用了 `refresh_token` 授权，则同时保留 **`offline_access`**。
+4. 点击 **Create client**，立即复制 **Client ID** 与 **Client Secret**——密钥只显示一次。
+
+#### 2. 在 Prism 中添加来源
+
+进入 **Admin → OAuth Sources → Add source**：
+
+| 字段          | 值                               |
+| ------------- | -------------------------------- |
+| Slug          | `cloudflare`（或任意唯一键）     |
+| 提供商        | **Cloudflare**                   |
+| 显示名称      | `Cloudflare`（显示在登录按钮上） |
+| Client ID     | 从 Cloudflare 复制               |
+| Client Secret | 从 Cloudflare 复制               |
+
+保存后，登录页面会立即出现该按钮。
+
+#### 注意事项
+
+- Prism 请求的 scope 为 `openid offline_access`，并按标准声明映射 OIDC 用户信息（`sub` 作为提供商 ID，`name`/`preferred_username`，`picture`）。
+- **邮箱：** 仅当用户信息响应将邮箱标记为已验证（`email_verified`）时，Prism 才信任该 Cloudflare 邮箱。若在所授予的 scope 下 Cloudflare 未返回已验证邮箱，用户将获得占位邮箱（`cloudflare_<id>@prism.local`）且初始未验证——之后可在个人资料设置中添加并验证真实邮箱。与 Telegram、X 流程一致。
+- **刷新令牌：** 要让连接页的**刷新**按钮生效，OAuth 客户端必须启用 `refresh_token` 授权，且来源需保留 `offline_access` scope（Prism 默认发送）。否则 Cloudflare 不返回 `refresh_token`，用户须重新连接以续期。
+- **私有与公开客户端：** 新建的 OAuth 客户端为**私有**——只有创建它的账号成员才能授权。要让任意 Cloudflare 用户登录，需完成 Cloudflare 的相关要求并将客户端可见性改为**公开**（此操作不可逆）。
+- 令牌端点接受 `client_secret_post`，因此你无需配置 PKCE 或 HTTP Basic。
 
 ## 通用 OpenID Connect
 

--- a/src/lib/providerIcons.ts
+++ b/src/lib/providerIcons.ts
@@ -8,6 +8,7 @@ export const PROVIDER_COLORS: Record<string, string> = {
   discord: "#5865f2",
   telegram: "#2AABEE",
   x: "#000000",
+  cloudflare: "#F38020",
 };
 
 export const PROVIDER_ICON_URLS: Record<string, string> = {
@@ -17,6 +18,7 @@ export const PROVIDER_ICON_URLS: Record<string, string> = {
   discord: "https://cdn.simpleicons.org/discord",
   telegram: "https://cdn.simpleicons.org/telegram",
   x: "https://cdn.simpleicons.org/x/000000",
+  cloudflare: "https://cdn.simpleicons.org/cloudflare",
 };
 
 /** Pick the icon URL for a provider entry on the login / connections page.

--- a/src/pages/admin/AdminConnections.tsx
+++ b/src/pages/admin/AdminConnections.tsx
@@ -112,6 +112,7 @@ const PROVIDER_OPTIONS = [
   { value: "discord", label: "Discord" },
   { value: "telegram", label: "Telegram" },
   { value: "x", label: "X (Twitter)" },
+  { value: "cloudflare", label: "Cloudflare" },
   { value: "oidc", label: "Generic OpenID Connect" },
   { value: "oauth2", label: "Generic OAuth 2" },
 ];

--- a/worker/lib/providerIcons.ts
+++ b/worker/lib/providerIcons.ts
@@ -12,6 +12,7 @@ export const PROVIDER_ICON_URLS: Record<string, string> = {
   discord: "https://cdn.simpleicons.org/discord",
   telegram: "https://cdn.simpleicons.org/telegram",
   x: "https://cdn.simpleicons.org/x",
+  cloudflare: "https://cdn.simpleicons.org/cloudflare",
 };
 
 // Providers whose built-in default icon is a near-pure-black silhouette

--- a/worker/routes/admin.ts
+++ b/worker/routes/admin.ts
@@ -2862,6 +2862,7 @@ const VALID_PROVIDERS = new Set([
   "discord",
   "telegram",
   "x",
+  "cloudflare",
   "oidc",
   "oauth2",
 ]);

--- a/worker/routes/connections.ts
+++ b/worker/routes/connections.ts
@@ -124,6 +124,21 @@ const PROVIDER_DEFS: Record<string, ProviderDef> = {
       "https://api.twitter.com/2/users/me?user.fields=profile_image_url,name,username",
     scopes: "users.read tweet.read offline.access",
   },
+  // Cloudflare — first-party OAuth 2.0 / OpenID Connect provider
+  // (dashboard: Manage Account -> OAuth clients). Fixed OIDC endpoints, taken
+  // from https://dash.cloudflare.com/.well-known/openid-configuration:
+  //   * `openid` yields the stable `sub` used as the provider_user_id.
+  //   * `offline_access` unlocks refresh_token issuance — the OAuth client must
+  //     also enable the refresh_token grant type for a token to come back.
+  //   * The token endpoint accepts client_secret_post, so the standard
+  //     body-based code exchange works unchanged — no PKCE or HTTP Basic
+  //     special-casing (unlike X). Profile extraction reuses the OIDC branch.
+  cloudflare: {
+    authUrl: "https://dash.cloudflare.com/oauth2/auth",
+    tokenUrl: "https://dash.cloudflare.com/oauth2/token",
+    userUrl: "https://dash.cloudflare.com/oauth2/userinfo",
+    scopes: "openid offline_access",
+  },
   // Generic providers — all URLs/scopes are configured per-source in oauth_sources table
   oidc: {
     authUrl: "",
@@ -1673,6 +1688,7 @@ function extractProviderUserId(
       return String(profile.id ?? "");
     case "google":
     case "oidc":
+    case "cloudflare":
       return String(profile.sub ?? "");
     default:
       // oauth2 and unknown — try sub first (OIDC-style), then id
@@ -1714,6 +1730,7 @@ function extractProviderEmail(
       return profile.verified === true ? email : null;
     case "google":
     case "oidc":
+    case "cloudflare":
       return profile.email_verified === true ? email : null;
     case "github":
       // The connection callback explicitly hits /user/emails and only puts a
@@ -1739,6 +1756,7 @@ function extractDisplayName(
       return (profile.name as string) || (profile.login as string) || "User";
     case "google":
     case "oidc":
+    case "cloudflare":
       return (
         (profile.name as string) ||
         (profile.preferred_username as string) ||
@@ -1809,6 +1827,7 @@ function extractProviderAvatar(
       return (profile.avatar_url as string) ?? null;
     case "google":
     case "oidc":
+    case "cloudflare":
       return (profile.picture as string) ?? null;
     case "discord": {
       const id = profile.id as string;


### PR DESCRIPTION
The Cloudflare dashboard is itself an OpenID Connect provider — the same one that authorises tools like Wrangler — so it can back "Sign in with Cloudflare" directly.

Its endpoints are fixed (dash.cloudflare.com/oauth2/{auth,token,userinfo}), taken from the published openid-configuration, so unlike a Generic OIDC source an operator enters no URLs: only client ID and secret. The token endpoint accepts client_secret_post, so the standard body-based code exchange applies with no PKCE or HTTP Basic special-casing of the kind X needs, and profile extraction reuses the existing OIDC branch — `sub` for the provider user ID, `email_verified` before trusting the address.

Scopes are `openid offline_access`: `openid` yields the stable `sub`, and `offline_access` unlocks refresh tokens — the OAuth client must also enable the refresh_token grant type for one to come back.

Adds the provider to the admin source dropdown and VALID_PROVIDERS, an icon and brand colour, and documents it in the social-login guides and READMEs.

See https://developers.cloudflare.com/fundamentals/oauth/ for details.

## Sourcery 摘要

将“使用 Cloudflare 登录”启用为内置社交登录源。

新功能：
- 将 Cloudflare 添加为内置 OAuth/OpenID Connect 登录提供商，使用固定端点和标准用户资料处理方式。

增强功能：
- 在管理员 OAuth 源配置中提供 Cloudflare，并支持品牌图标和颜色。

文档：
- 在英文和中文指南以及项目 README 中，记录 Cloudflare OAuth 客户端设置、作用域、刷新令牌要求、电子邮件验证和客户端可见性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable Sign in with Cloudflare as a built-in social login source.

New Features:
- Add Cloudflare as a built-in OAuth/OpenID Connect login provider with fixed endpoints and standard profile handling.

Enhancements:
- Expose Cloudflare in administrator OAuth source configuration and provide branded icon and colour support.

Documentation:
- Document Cloudflare OAuth client setup, scopes, refresh-token requirements, email verification, and client visibility in English and Chinese guides and project READMEs.

</details>