### PR TITLE
fix(scripts): correct migrations_dir when relocating the deploy confi…

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -225,6 +225,14 @@ if (-not $SkipFrontend) {
         $cfg = Get-Content $distConfig -Raw | ConvertFrom-Json
         $cfg.main = 'dist/prism/index.js'
         if ($cfg.assets) { $cfg.assets.directory = './dist/client' }
+        # migrations_dir is emitted as '../../worker/db/migrations' — correct
+        # from dist/prism/, but two levels above the repo once the config sits
+        # at the root, where wrangler reports "No migrations present".
+        foreach ($db in $cfg.d1_databases) {
+            if ($db.migrations_dir -and $db.migrations_dir.StartsWith('../../')) {
+                $db.migrations_dir = $db.migrations_dir.Substring(6)
+            }
+        }
         $cfg | ConvertTo-Json -Depth 100 -Compress | Set-Content (Join-Path $Root 'wrangler.json') -NoNewline
         Ok 'wrangler.json (root) updated for deploy'
     } else {

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -327,6 +327,13 @@ def build_frontend(pm: str) -> None:
         cfg["main"] = "dist/prism/index.js"
         if "assets" in cfg and isinstance(cfg["assets"], dict):
             cfg["assets"]["directory"] = "./dist/client"
+        # migrations_dir is emitted as "../../worker/db/migrations" — correct
+        # from dist/prism/, but two levels above the repo once the config sits
+        # at the root, where wrangler reports "No migrations present".
+        for db in cfg.get("d1_databases") or []:
+            md = db.get("migrations_dir")
+            if isinstance(md, str) and md.startswith("../../"):
+                db["migrations_dir"] = md[len("../../"):]
         with (ROOT / "wrangler.json").open("w", encoding="utf-8") as f:
             _json.dump(cfg, f, indent=2)
         ok("wrangler.json (root) updated for deploy")

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -208,13 +208,21 @@ if [ "$SKIP_FRONTEND" = false ]; then
   # worker/index.ts and skip Vite's SSR work entirely.
   #
   # Solution: copy that emitted config into wrangler.json at the project
-  # root (wrangler picks .json over .jsonc when both exist) and rewrite the
-  # two paths that were relative to dist/prism/ to be relative to the root.
+  # root (wrangler picks .json over .jsonc when both exist) and rewrite every
+  # path that was relative to dist/prism/ so it is relative to the root.
+  #
+  # migrations_dir is one of them, and it is the easiest to forget because
+  # nothing fails until a deploy actually reaches the migration step: Vite
+  # emits "../../worker/db/migrations", which is correct from dist/prism/ but
+  # points two levels *above* the repo once the config sits at the root. On a
+  # CI runner with the checkout at /opt/buildhome/repo that resolves to
+  # /opt/worker/db/migrations and wrangler reports "No migrations present".
   step "Generating deploy-ready wrangler.json"
   if [ -f dist/prism/wrangler.json ]; then
     sed \
       -e 's|"main":"index\.js"|"main":"dist/prism/index.js"|' \
       -e 's|"directory":"\.\./client"|"directory":"./dist/client"|' \
+      -e 's|"migrations_dir":"\.\./\.\./|"migrations_dir":"|g' \
       dist/prism/wrangler.json > wrangler.json
     ok "wrangler.json (root) updated for deploy"
   else

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -114,6 +114,21 @@ try {
     }
 
     # ── Confirm ────────────────────────────────────────────────────────────────
+    # A CI runner has no terminal to prompt on, and the commit that triggered
+    # the build is already the approval — so a recognised runner implies -Yes.
+    #
+    # This keys on CI environment variables rather than "the host is not
+    # interactive" on purpose. Someone running this from a scheduled task or an
+    # editor has not consented to a production deploy, and should still meet the
+    # prompt (and Read-Host's failure) rather than silently ship.
+    $inCi = @('WORKERS_CI', 'CI', 'GITHUB_ACTIONS', 'GITLAB_CI') |
+        Where-Object { [Environment]::GetEnvironmentVariable($_) }
+    if (-not $Yes -and -not $DryRun -and $inCi) {
+        Step 'Confirm'
+        Info 'CI detected - proceeding without an interactive confirmation'
+        $Yes = $true
+    }
+
     if (-not $Yes -and -not $DryRun) {
         $target = 'migrations + deploy'
         if ($MigrationsOnly)  { $target = 'migrations only' }

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -10,6 +10,7 @@ live, and the currently-deployed code ignores columns it does not know about.
 """
 
 import argparse
+import os
 import platform
 import re
 import shutil
@@ -115,7 +116,25 @@ def git_summary() -> None:
     info(f"commit:   {head} on {branch}")
 
 
+# A CI runner has no terminal to prompt on, and the commit that triggered the
+# build is already the approval — so a recognised runner implies --yes.
+#
+# This keys on CI environment variables rather than "stdin is not a tty" on
+# purpose. Someone piping input into this script, or running it from a cron or
+# an editor task, has not consented to a production deploy; they should still
+# hit the hard error in confirm() rather than silently ship.
+CI_ENV_VARS = ("WORKERS_CI", "CI", "GITHUB_ACTIONS", "GITLAB_CI")
+
+
+def running_in_ci() -> bool:
+    return any(os.environ.get(v) for v in CI_ENV_VARS)
+
+
 def confirm(target: str) -> None:
+    if running_in_ci():
+        step("Confirm")
+        info("CI detected - proceeding without an interactive confirmation")
+        return
     print()
     try:
         reply = input(f"Apply to PRODUCTION ({target})? [y/N] ")

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -140,6 +140,20 @@ if [ "$SKIP_MIGRATIONS" = false ]; then
 fi
 
 # ── Confirm ────────────────────────────────────────────────────────────────────
+# A CI runner has no terminal to prompt on, and the commit that triggered the
+# build is already the approval — so a recognised runner implies --yes.
+#
+# This keys on CI environment variables rather than "stdin is not a tty" on
+# purpose. Someone piping input into this script, or running it from a cron or
+# an editor task, has not consented to a production deploy; they should still
+# hit the hard error below rather than silently ship.
+if [ "$ASSUME_YES" = false ] && [ "$DRY_RUN" = false ] &&
+  [ -n "${WORKERS_CI:-}${CI:-}${GITHUB_ACTIONS:-}${GITLAB_CI:-}" ]; then
+  ASSUME_YES=true
+  step "Confirm"
+  info "CI detected - proceeding without an interactive confirmation"
+fi
+
 if [ "$ASSUME_YES" = false ] && [ "$DRY_RUN" = false ]; then
   target="migrations + deploy"
   [ "$MIGRATIONS_ONLY" = true ] && target="migrations only"


### PR DESCRIPTION
…g, and

auto-confirm in CI

Two separate faults broke the Workers Builds deploy from main.

migrations_dir was left pointing outside the repo. Vite emits dist/prism/wrangler.json with "../../worker/db/migrations", correct relative to that directory. build.* copies the config to the project root and rewrites the paths that move as a result — but only main and assets.directory, never migrations_dir. At the root the "../../" then climbs two levels above the checkout: on the runner that is /opt/worker/db/migrations, and wrangler reports "No migrations present". Nothing catches it earlier because the `migrations list` call tolerates failure; only `migrations apply` is fatal.

The confirmation prompt had no terminal to read. A CI runner has no tty, so `read </dev/tty` failed and the script exited telling the operator to pass --yes. A recognised CI runner now implies --yes: the commit that triggered the build is the approval. This keys on CI environment variables rather than on "stdin is not a tty" deliberately — someone piping input in, or running from cron or an editor task, has not consented to a production deploy and should still meet the hard error.

Both fixes are applied to all three ports (sh, py, ps1) so they cannot drift.

## Sourcery 总结

通过在配置迁移到仓库根目录后保留迁移发现功能，并在 CI 中启用安全的非交互式确认，修复 Workers Builds 部署问题。

Bug 修复：
- 修正将 Wrangler 配置迁移到仓库根目录后部署配置的迁移路径。
- 允许在已识别的 CI 运行器上自动进行部署确认，同时在 CI 环境之外继续要求显式确认。

增强功能：
- 在 Shell、Python 和 PowerShell 脚本中统一迁移路径和 CI 确认行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Workers Builds deployments by preserving migration discovery after configuration relocation and enabling safe non-interactive confirmation in CI.

Bug Fixes:
- Correct deploy configuration migration paths after relocating Wrangler configuration to the repository root.
- Allow deploy confirmation to proceed automatically on recognized CI runners while preserving explicit confirmation requirements outside CI.

Enhancements:
- Apply consistent migration path and CI confirmation behavior across shell, Python, and PowerShell scripts.

</details>