### PR TITLE
ci: deploy non-production Workers via GitHub Actions

### DIFF
--- a/.github/workflows/deploy-nonprod.yml
+++ b/.github/workflows/deploy-nonprod.yml
@@ -1,0 +1,95 @@
+name: Deploy non-production
+
+# Production (the `prism` Worker) is built and deployed by Cloudflare Workers
+# Builds -- the Git repository is connected in the dashboard under the Worker's
+# Settings -> Builds, which runs on pushes to the production branch. This
+# workflow deliberately covers ONLY the non-production Workers
+# (prism-staging / prism-preview) and never touches production.
+#
+# Triggers:
+#   * push to the `staging` branch   -> deploy the staging Worker
+#   * push to the `preview` branch   -> deploy the preview Worker
+#   * manual run (workflow_dispatch) -> deploy the chosen environment
+#
+# Requires a repository secret CLOUDFLARE_API_TOKEN scoped to the SiiWay
+# account with: Workers Scripts:Edit, D1:Edit, Workers KV Storage:Edit, and
+# Secrets Store:Read (the Workers bind a Secrets Store SECRETS_KEY). The account
+# id is pinned in wrangler.jsonc, so no account-id secret is needed.
+
+on:
+  push:
+    branches: [staging, preview]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Non-production environment to deploy
+        type: choice
+        options:
+          - staging
+          - preview
+        required: true
+
+# One in-flight run per environment; a newer push supersedes an older run of
+# the same environment, while staging and preview never cancel each other.
+concurrency:
+  group: deploy-nonprod-${{ github.event.inputs.environment || github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve target environment
+        id: target
+        run: echo "env=${{ github.event.inputs.environment || github.ref_name }}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Setup Rust (wasm32)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Bun install cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Cache Cargo + WASM build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            pow/target
+          key: cargo-${{ runner.os }}-${{ hashFiles('pow/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build PoW WASM
+        run: |
+          cargo build --release --target wasm32-unknown-unknown --manifest-path pow/Cargo.toml
+          cp pow/target/wasm32-unknown-unknown/release/prism_pow.wasm public/pow.wasm
+
+      - name: Apply D1 migrations (${{ steps.target.outputs.env }})
+        run: bun run db:migrate:${{ steps.target.outputs.env }}
+
+      - name: Build and deploy (${{ steps.target.outputs.env }})
+        run: bun run deploy:${{ steps.target.outputs.env }}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -267,6 +267,23 @@ wrangler kv namespace create prism-staging-cache
 
 …then run `bun db:migrate:staging` before the first `bun deploy:staging`.
 
+### CI (GitHub Actions)
+
+Production is built and deployed by **Cloudflare Workers Builds** (the Git
+repository is connected in the dashboard under the `prism` Worker's
+**Settings → Builds**), which runs on pushes to the production branch.
+
+The non-production Workers are deployed by GitHub Actions instead
+(`.github/workflows/deploy-nonprod.yml`): pushing to the `staging` or `preview`
+branch — or running the workflow manually and picking an environment — applies
+that environment's D1 migrations and deploys its Worker. The two mechanisms
+never overlap: the workflow only ever touches `prism-staging` / `prism-preview`.
+
+It needs one repository secret, `CLOUDFLARE_API_TOKEN`, scoped to the account
+with **Workers Scripts:Edit**, **D1:Edit**, **Workers KV Storage:Edit**, and
+**Secrets Store:Read** (the Workers bind a Secrets Store `SECRETS_KEY`). The
+account id is pinned in `wrangler.jsonc`, so no account-id secret is required.
+
 ## Social login setup
 
 Each provider requires an OAuth app registration. Add OAuth Sources in

--- a/docs/zh/getting-started.md
+++ b/docs/zh/getting-started.md
@@ -216,6 +216,21 @@ wrangler kv namespace create prism-staging-cache
 
 ……然后在首次 `bun deploy:staging` 之前运行 `bun db:migrate:staging`。
 
+### CI（GitHub Actions）
+
+生产环境由 **Cloudflare Workers Builds** 构建并部署（在控制台 `prism` Worker 的
+**Settings → Builds** 中连接了 Git 仓库），在推送到生产分支时触发。
+
+非生产 Worker 则由 GitHub Actions 部署（`.github/workflows/deploy-nonprod.yml`）：
+推送到 `staging` 或 `preview` 分支——或手动运行该工作流并选择环境——会为该环境应用
+D1 迁移并部署其 Worker。两套机制互不重叠：该工作流只会触及 `prism-staging` /
+`prism-preview`。
+
+它需要一个仓库 Secret `CLOUDFLARE_API_TOKEN`，其权限范围需覆盖该账号的
+**Workers Scripts:Edit**、**D1:Edit**、**Workers KV Storage:Edit** 与
+**Secrets Store:Read**（这些 Worker 绑定了 Secrets Store 中的 `SECRETS_KEY`）。账号
+ID 已固定写在 `wrangler.jsonc` 中，因此无需再配置账号 ID 的 Secret。
+
 ## 社交登录配置
 
 每个 provider 都需要先到对应平台创建 OAuth 应用。在 **Admin → OAuth Sources** 添加 OAuth 源 — 同一类型可以加多个，每个有独立 slug。详见 [社交登录配置](social-login.md)；回调 URL 的格式见 [OAuth / OIDC 指南](oauth.md)。


### PR DESCRIPTION
Production stays on Cloudflare Workers Builds (the Git repo is connected in the dashboard under the prism Worker's Settings -> Builds). This adds a GitHub Actions workflow for the non-production Workers only, so the two mechanisms never overlap.

.github/workflows/deploy-nonprod.yml deploys prism-staging / prism-preview on a push to the staging / preview branch, or on a manual run with the environment chosen as input. Each run installs deps, builds the PoW WASM (Rust wasm32), applies that environment's D1 migrations, then builds and deploys through the existing bun run db:migrate:<env> / deploy:<env> scripts. Bun and Cargo caches are keyed on bun.lock / pow/Cargo.lock.

Requires a CLOUDFLARE_API_TOKEN repository secret (Workers Scripts:Edit, D1:Edit, Workers KV Storage:Edit, Secrets Store:Read); the account id is pinned in wrangler.jsonc. Docs updated (EN + ZH).

## Sourcery 摘要

通过 GitHub Actions 自动化 staging 和 preview Worker 的部署，同时保留 Cloudflare Workers Builds 用于生产环境。

新功能：
- 在分支推送或手动选择环境时，为 staging 和 preview Worker 添加 GitHub Actions 部署。

改进：
- 将非生产环境的部署自动化与生产环境的 Cloudflare Workers Builds 流程分离。
- 自动化 PoW WASM 构建、特定环境的 D1 迁移以及部署，并缓存依赖项和 Rust 构建产物。

CI：
- 配置非生产环境部署工作流，包括限定范围的 Cloudflare 身份验证、按环境设置的并发控制，以及 Bun/Cargo 缓存。

文档：
- 在中英文入门指南中记录非生产环境的 GitHub Actions 部署、生产环境部署的负责方，以及所需的 Cloudflare API 令牌权限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automate staging and preview Worker deployments through GitHub Actions while preserving Cloudflare Workers Builds for production.

New Features:
- Add GitHub Actions deployments for the staging and preview Workers on branch pushes or manual environment selection.

Enhancements:
- Keep non-production deployment automation separate from the production Cloudflare Workers Builds pipeline.
- Automate PoW WASM builds, environment-specific D1 migrations, and deployment with dependency and Rust build caching.

CI:
- Configure the non-production deployment workflow with scoped Cloudflare authentication, per-environment concurrency, and Bun/Cargo caching.

Documentation:
- Document non-production GitHub Actions deployments, production deployment ownership, and required Cloudflare API token permissions in English and Chinese getting-started guides.

</details>