### PR TITLE
fix(captcha): migration backfill, Cap double-redeem, widget remounts, admin reorder

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,7 +81,7 @@ worker/
 │   ├── crypto.ts           # randomId, hashPassword/verifyPassword (PBKDF2)
 │   ├── pow.ts              # Signed challenge issue/verify (HMAC + expiry + single-use)
 │   ├── geetest.ts          # GeeTest v4 server-side verification (HMAC sign + validate)
-│   ├── cap.ts              # Cap captcha — embedded (capjs-core + KV) and external verify
+│   ├── cap.ts              # Cap captcha — embedded (capjs-core, deterministic token) and external verify
 │   ├── captchaPublic.ts    # buildPublicCaptcha() — public captcha descriptor for payloads
 │   ├── jwt.ts              # signJWT / verifyJWT (HS256), RS256 ID-token signing
 │   ├── totp.ts             # TOTP / HOTP (RFC 6238), backup codes
@@ -467,12 +467,15 @@ are self-contained on the edge:
   HMAC-SHA256 and POSTs to GeeTest's validate endpoint. `geetest_fail_open`
   governs the outcome on a GeeTest outage (default: fail closed).
 - **Cap** (`lib/cap.ts`) — embedded mode runs `capjs-core` in the Worker
-  (stateless signed-JWT challenges; single-use nonce + redeem token in
-  `KV_CACHE`; HMAC secret derived from the JWT secret) via
+  (stateless signed-JWT challenges; HMAC secret derived from the JWT secret) via
   `POST /api/auth/cap/{challenge,redeem}`; external mode validates against a
-  self-hosted Cap Standalone server. `capjs-core` lazily imports `esbuild` /
-  `javascript-obfuscator` for high instrumentation obfuscation levels — both are
-  aliased to a stub in `wrangler.jsonc` since the embedded path pins level ≤ 3.
+  self-hosted Cap Standalone server. `redeem` mints a **deterministic** token
+  from the challenge (`sig.exp.HMAC`) so the widget's speculative + final redeem
+  of one challenge agree and one solved challenge yields exactly one token;
+  single use is enforced at the gate via the atomic D1 replay-claim table.
+  `capjs-core` lazily imports `esbuild` / `javascript-obfuscator` for high
+  instrumentation obfuscation levels — both are aliased to a stub in
+  `wrangler.jsonc` since the embedded path pins level ≤ 3.
 
 ## Secrets at rest
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,11 +130,11 @@ silently drop bot protection.
 captcha. Two modes:
 
 - **Embedded** (default) — Cap runs inside the Worker via `capjs-core`. Challenges
-  are stateless signed JWTs; the single-use replay guard and redeem-token lookup
-  are backed by `KV_CACHE`; the HMAC secret is derived from the server JWT secret,
-  so there is **no extra binding or server to run**. Tuned by
-  `cap_challenge_count` / `cap_challenge_difficulty` and
-  `cap_instrumentation`.
+  are stateless signed JWTs and the redeem token is derived deterministically
+  from the challenge, so redeeming is idempotent; single use is enforced once at
+  the gate via the atomic D1 replay-claim table. The HMAC secret is derived from
+  the server JWT secret, so there is **no extra binding or server to run**. Tuned
+  by `cap_challenge_count` / `cap_challenge_difficulty` and `cap_instrumentation`.
 - **External** — point `cap_api_endpoint` (+ `cap_site_key` / `cap_secret_key`) at
   a self-hosted [Cap Standalone](https://trycap.dev/guide/standalone/) server.
 

--- a/docs/zh/architecture.md
+++ b/docs/zh/architecture.md
@@ -65,7 +65,7 @@ worker/
 │   ├── crypto.ts           # randomId、PBKDF2 哈希
 │   ├── pow.ts              # 签名挑战签发/校验（HMAC + 过期 + 单次）
 │   ├── geetest.ts          # 极验 v4 服务端校验（HMAC 签名 + validate）
-│   ├── cap.ts              # Cap 验证码 — 内嵌（capjs-core + KV）与外部校验
+│   ├── cap.ts              # Cap 验证码 — 内嵌（capjs-core，确定性令牌）与外部校验
 │   ├── captchaPublic.ts    # buildPublicCaptcha() — 下发给各 payload 的公开验证码描述
 │   ├── jwt.ts              # signJWT / verifyJWT（HS256），ID Token RS256
 │   ├── totp.ts             # TOTP / HOTP（RFC 6238），备用码

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -98,7 +98,7 @@ Provider：`turnstile`、`hcaptcha`、`recaptcha`、`pow`（内置 Rust→WASM �
 
 [Cap](https://trycap.dev) 是一个自建、注重隐私的工作量证明验证码。两种模式：
 
-- **内嵌**（默认）——通过 `capjs-core` 在 Worker 内运行 Cap。挑战是无状态的签名 JWT；单次使用的重放防护与兑换令牌查找由 `KV_CACHE` 支撑；HMAC 密钥从服务端 JWT 密钥派生，因此**无需额外绑定或服务器**。由 `cap_challenge_count` / `cap_challenge_difficulty` 与 `cap_instrumentation` 调节。
+- **内嵌**（默认）——通过 `capjs-core` 在 Worker 内运行 Cap。挑战是无状态的签名 JWT，兑换令牌由挑战确定性派生，因此兑换是幂等的；单次使用在网关处通过原子的 D1 重放声明表强制一次。HMAC 密钥从服务端 JWT 密钥派生，因此**无需额外绑定或服务器**。由 `cap_challenge_count` / `cap_challenge_difficulty` 与 `cap_instrumentation` 调节。
 - **外部**——将 `cap_api_endpoint`（以及 `cap_site_key` / `cap_secret_key`）指向自建的 [Cap Standalone](https://trycap.dev/guide/standalone/) 服务器。
 
 Cap 是内置 `pow` provider 的现代替代方案，`pow` 仍然可用（见下）。

--- a/src/components/Captcha.tsx
+++ b/src/components/Captcha.tsx
@@ -195,6 +195,22 @@ function ProviderWidget({
   const [geetestReady, setGeetestReady] = useState(false);
   const geetestObjRef = useRef<GeetestCaptchaObj | null>(null);
 
+  // Read callbacks and `t` through refs so the widget effects don't list them
+  // as dependencies. `onVerified`/`onError`/`t` can change identity on any
+  // parent re-render (e.g. a keystroke in the login form); if the effects
+  // depended on them, every such render would tear down and re-create the
+  // widget — re-fetching challenges, re-initialising the GeeTest widget, and
+  // tripping "too many requests". The effects below depend only on `provider`
+  // and the primitive config values they actually read.
+  const onVerifiedRef = useRef(onVerified);
+  const onErrorRef = useRef(onError);
+  const tRef = useRef(t);
+  useEffect(() => {
+    onVerifiedRef.current = onVerified;
+    onErrorRef.current = onError;
+    tRef.current = t;
+  });
+
   // ─── Turnstile ──────────────────────────────────────────────────────────
   useEffect(() => {
     if (provider !== "turnstile") return;
@@ -208,12 +224,13 @@ function ProviderWidget({
       widgetIdRef.current = widgetApi("turnstile").render(containerRef.current, {
         sitekey: target.sitekey,
         callback: (token: string) =>
-          onVerified({
+          onVerifiedRef.current({
             provider: "turnstile",
             captcha_token: token,
             captcha_variant: target.variant,
           }),
-        "error-callback": () => onError?.(t("captcha.turnstileFailed")),
+        "error-callback": () =>
+          onErrorRef.current?.(tRef.current("captcha.turnstileFailed")),
       });
     });
     return () => {
@@ -221,7 +238,12 @@ function ProviderWidget({
       widgetIdRef.current = null;
       removeScript();
     };
-  }, [provider, captcha, onVerified, onError, t]);
+  }, [
+    provider,
+    captcha.turnstile_endpoint,
+    captcha.turnstile_site_key,
+    captcha.turnstile_china_site_key,
+  ]);
 
   // ─── hCaptcha ───────────────────────────────────────────────────────────
   useEffect(() => {
@@ -233,7 +255,7 @@ function ProviderWidget({
         widgetIdRef.current = widgetApi("hcaptcha").render(containerRef.current, {
           sitekey: captcha.hcaptcha_site_key,
           callback: (token: string) =>
-            onVerified({ provider: "hcaptcha", captcha_token: token }),
+            onVerifiedRef.current({ provider: "hcaptcha", captcha_token: token }),
         });
       },
     );
@@ -242,7 +264,7 @@ function ProviderWidget({
       widgetIdRef.current = null;
       removeScript();
     };
-  }, [provider, captcha, onVerified, onError]);
+  }, [provider, captcha.hcaptcha_site_key]);
 
   // ─── reCAPTCHA v3 ───────────────────────────────────────────────────────
   useEffect(() => {
@@ -255,14 +277,14 @@ function ProviderWidget({
         grecaptcha.ready(async () => {
           try {
             const token = await grecaptcha.execute(siteKey, { action: "login" });
-            onVerified({ provider: "recaptcha", captcha_token: token });
+            onVerifiedRef.current({ provider: "recaptcha", captcha_token: token });
           } catch {
-            onError?.(t("captcha.recaptchaFailed"));
+            onErrorRef.current?.(tRef.current("captcha.recaptchaFailed"));
           }
         });
       },
     );
-  }, [provider, captcha, onVerified, onError, t]);
+  }, [provider, captcha.recaptcha_site_key]);
 
   // ─── Proof of Work ──────────────────────────────────────────────────────
   const solveChallenge = useCallback(async () => {
@@ -270,13 +292,17 @@ function ProviderWidget({
     try {
       const { challenge, difficulty } = await api.powChallenge();
       const nonce = await solvePoW(challenge, difficulty);
-      onVerified({ provider: "pow", pow_challenge: challenge, pow_nonce: nonce });
+      onVerifiedRef.current({
+        provider: "pow",
+        pow_challenge: challenge,
+        pow_nonce: nonce,
+      });
       setPowState("done");
     } catch {
       setPowState("error");
-      onError?.(t("captcha.powFailed"));
+      onErrorRef.current?.(tRef.current("captcha.powFailed"));
     }
-  }, [api, onVerified, onError, t]);
+  }, [api]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- async task on provider change; setState happens inside the async flow
@@ -291,7 +317,7 @@ function ProviderWidget({
       () => {
         const initGeetest4 = (window as unknown as GeetestWindow).initGeetest4;
         if (!initGeetest4) {
-          onError?.(t("captcha.geetestFailed"));
+          onErrorRef.current?.(tRef.current("captcha.geetestFailed"));
           return;
         }
         initGeetest4(
@@ -308,10 +334,12 @@ function ProviderWidget({
             captchaObj.onSuccess(() => {
               const result = captchaObj.getValidate();
               if (result) {
-                onVerified({ provider: "geetest", geetest: result });
+                onVerifiedRef.current({ provider: "geetest", geetest: result });
               }
             });
-            captchaObj.onError(() => onError?.(t("captcha.geetestFailed")));
+            captchaObj.onError(() =>
+              onErrorRef.current?.(tRef.current("captcha.geetestFailed")),
+            );
           },
         );
       },
@@ -325,7 +353,7 @@ function ProviderWidget({
       geetestObjRef.current = null;
       removeScript();
     };
-  }, [provider, captcha, onVerified, onError, t]);
+  }, [provider, captcha.geetest_captcha_id]);
 
   // ─── Cap ────────────────────────────────────────────────────────────────
   useEffect(() => {
@@ -352,10 +380,12 @@ function ProviderWidget({
       el.addEventListener("solve", (e: Event) => {
         const detail = (e as CustomEvent<{ token: string }>).detail;
         if (detail?.token) {
-          onVerified({ provider: "cap", cap_token: detail.token });
+          onVerifiedRef.current({ provider: "cap", cap_token: detail.token });
         }
       });
-      el.addEventListener("error", () => onError?.(t("captcha.capFailed")));
+      el.addEventListener("error", () =>
+        onErrorRef.current?.(tRef.current("captcha.capFailed")),
+      );
       containerRef.current.appendChild(el);
     });
 
@@ -363,7 +393,12 @@ function ProviderWidget({
       cancelled = true;
       el?.remove();
     };
-  }, [provider, captcha, onVerified, onError, t]);
+  }, [
+    provider,
+    captcha.cap_mode,
+    captcha.cap_api_endpoint,
+    captcha.cap_site_key,
+  ]);
 
   // ─── Render per provider ──────────────────────────────────────────────────
 

--- a/src/pages/admin/AdminSettings.tsx
+++ b/src/pages/admin/AdminSettings.tsx
@@ -300,6 +300,15 @@ export function AdminSettings() {
   ).filter((p) => p !== "none");
   const defaultProvider: CaptchaProvider = providerList[0] ?? "none";
   const alternateProviders: CaptchaProvider[] = providerList.slice(1);
+  // Display order for the alternates editor: enabled alternates first, in their
+  // actual configured order (so the ↑/↓ controls visibly move a row), then the
+  // not-yet-enabled providers pinned at the bottom in the canonical order.
+  const alternateOptions: CaptchaProvider[] = [
+    ...alternateProviders,
+    ...CAPTCHA_PROVIDERS.filter(
+      (p) => p !== defaultProvider && !alternateProviders.includes(p),
+    ),
+  ];
   const setProviderList = (list: CaptchaProvider[]) =>
     set("captcha_providers", list);
   // Change the default (element 0). "none" clears the whole set. Otherwise the
@@ -1329,8 +1338,7 @@ export function AdminSettings() {
                 <div
                   style={{ display: "flex", flexDirection: "column", gap: 6 }}
                 >
-                  {CAPTCHA_PROVIDERS.filter((p) => p !== defaultProvider).map(
-                    (p) => {
+                  {alternateOptions.map((p) => {
                       const enabled = alternateProviders.includes(p);
                       const pos = alternateProviders.indexOf(p);
                       return (
@@ -1371,8 +1379,7 @@ export function AdminSettings() {
                           )}
                         </div>
                       );
-                    },
-                  )}
+                    })}
                 </div>
               </Field>
             )}

--- a/worker/lib/cap.ts
+++ b/worker/lib/cap.ts
@@ -27,10 +27,6 @@ import { claimReplayValue } from "./securityState";
 /** Scope bound into the challenge JWT, so a token minted for captcha cannot be
  *  replayed against some other capjs-core surface. */
 const CAP_SCOPE = "prism-captcha";
-const TOKEN_PREFIX = "cap:token:";
-/** Redeem-token TTL. Matches capjs-core's default; the user must submit the
- *  form within this window after solving. */
-const TOKEN_TTL_MS = 20 * 60 * 1000;
 
 export interface CapEmbeddedOptions {
   challengeCount: number;
@@ -52,6 +48,81 @@ async function getCapSecret(env: Env): Promise<string> {
     .join("");
 }
 
+/** HMAC-SHA256(secret, msg) as hex. Used to mint/verify the deterministic
+ *  redeem token below. */
+async function capMac(secret: string, msg: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(msg),
+  );
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let r = 0;
+  for (let i = 0; i < a.length; i++) r |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return r === 0;
+}
+
+/** Decode a base64url segment (a JWT part) to a UTF-8 string. */
+function b64urlToString(seg: string): string | null {
+  try {
+    const b64 =
+      seg.replace(/-/g, "+").replace(/_/g, "/") +
+      "=".repeat((4 - (seg.length % 4)) % 4);
+    const bin = atob(b64);
+    const bytes = Uint8Array.from(bin, (ch) => ch.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The redeem token is deterministic per challenge:
+ *
+ *   token = `${challengeSig}.${exp}.${HMAC(capSecret, challengeSig + "." + exp)}`
+ *
+ * where `challengeSig` is the challenge JWT's signature segment (unique per
+ * challenge) and `exp` is the challenge's own expiry in ms (parsed from its
+ * payload). This is what makes redeem idempotent: the @cap.js/widget redeems a
+ * single challenge more than once (a speculative redeem while instrumentation
+ * runs, then a final one), and both must agree. A deterministic token also
+ * means one solved challenge yields exactly one token no matter how many times
+ * it is redeemed, so the proof-of-work cost is preserved — single use is then
+ * enforced once, at the gate, in verifyCapEmbedded.
+ */
+async function deriveCapToken(
+  secret: string,
+  challengeJwt: string,
+): Promise<string | null> {
+  const parts = challengeJwt.split(".");
+  if (parts.length !== 3) return null;
+  const sig = parts[2];
+  const payloadJson = b64urlToString(parts[1]);
+  if (!payloadJson) return null;
+  let exp: number;
+  try {
+    exp = Number((JSON.parse(payloadJson) as { exp?: number }).exp);
+  } catch {
+    return null;
+  }
+  if (!sig || !Number.isFinite(exp)) return null;
+  const mac = await capMac(secret, `${sig}.${exp}`);
+  return `${sig}.${exp}.${mac}`;
+}
+
 /** Mint a fresh embedded Cap challenge for the widget to solve. */
 export async function issueCapChallenge(
   env: Env,
@@ -70,83 +141,54 @@ export async function issueCapChallenge(
 }
 
 /**
- * Redeem a solved embedded Cap challenge, returning the opaque token the client
- * will later submit with the gated form. Replay of the *challenge* is prevented
- * via the KV-backed consumeNonce callback; the issued token is stored in KV so
- * verifyCapToken can confirm it later and burn it.
+ * Redeem a solved embedded Cap challenge, returning the token the client submits
+ * with the gated form. Verifies the challenge signature and the proof-of-work
+ * solutions, then mints a deterministic token for the challenge (see
+ * deriveCapToken). No server state is written here: because the token is a
+ * function of the challenge, the widget's speculative + final redeems produce
+ * the same value, and single use is enforced later at the gate.
  */
 export async function redeemCapChallenge(
   env: Env,
   body: ValidateChallengeBody,
 ): Promise<{ success: true; token: string } | { success: false }> {
   const secret = await getCapSecret(env);
-  const result = await validateChallenge(secret, body, {
-    scope: CAP_SCOPE,
-    tokenTtlMs: TOKEN_TTL_MS,
-    // Challenge single-use guard. Backed by the atomic D1 replay-claim table
-    // (conditional upsert) rather than a KV get-then-put, which is racy under
-    // concurrency and eventually consistent — two requests could both see the
-    // nonce absent and both redeem the same challenge.
-    consumeNonce: async (sigHex, ttlMs) =>
-      claimReplayValue(
-        env.DB,
-        "cap-nonce",
-        "",
-        sigHex,
-        Math.floor(Date.now() / 1000) + Math.ceil(ttlMs / 1000),
-      ),
-  });
+  // No consumeNonce: the widget legitimately redeems one challenge twice
+  // (speculative then final). capjs-core still checks the JWT signature, expiry
+  // and the PoW solutions here — that is what proves the challenge was solved.
+  const result = await validateChallenge(secret, body, { scope: CAP_SCOPE });
   if (!result.success) return { success: false };
 
-  // Persist the redeem token so the eventual form submission can be proven to
-  // have been issued by us (authenticity). Single-use of the token is enforced
-  // atomically at verify time via the replay-claim table, so this KV record
-  // only needs to answer "did we issue this, and is it still valid?".
-  const tokenKey = result.tokenKey ?? result.token;
-  await env.KV_CACHE.put(`${TOKEN_PREFIX}${tokenKey}`, String(result.expires), {
-    expirationTtl: Math.ceil(TOKEN_TTL_MS / 1000),
-  });
-  return { success: true, token: result.token };
+  const token = await deriveCapToken(secret, body.token);
+  if (!token) return { success: false };
+  return { success: true, token };
 }
 
-/** Re-derive the stored tokenKey from a user-submitted `id:secret` token,
- *  matching capjs-core's default signToken shape. */
-async function deriveTokenKey(token: string): Promise<string | null> {
-  const idx = token.indexOf(":");
-  if (idx === -1) return null;
-  const id = token.slice(0, idx);
-  const verToken = token.slice(idx + 1);
-  const digest = await crypto.subtle.digest(
-    "SHA-256",
-    new TextEncoder().encode(verToken),
-  );
-  const hex = Array.from(new Uint8Array(digest))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-  return `${id}:${hex}`;
-}
-
-/** Verify a submitted embedded Cap token: prove we issued it, that it hasn't
- *  expired, and that it hasn't already been used. */
+/** Verify a submitted embedded Cap token: prove we issued it (HMAC), that it
+ *  hasn't expired, and that it hasn't already been used. */
 async function verifyCapEmbedded(env: Env, token: string): Promise<boolean> {
-  const tokenKey = await deriveTokenKey(token);
-  if (!tokenKey) return false;
+  const parts = token.split(".");
+  if (parts.length !== 3) return false;
+  const [sig, expStr, mac] = parts;
 
-  // Authenticity + expiry: the KV record was written at redeem time.
-  const stored = await env.KV_CACHE.get(`${TOKEN_PREFIX}${tokenKey}`);
-  if (!stored) return false;
-  const expires = Number(stored);
-  if (!Number.isFinite(expires) || expires <= Date.now()) return false;
+  // Authenticity: only we can produce this MAC, and only after a solve (redeem).
+  const secret = await getCapSecret(env);
+  const expected = await capMac(secret, `${sig}.${expStr}`);
+  if (!timingSafeEqual(mac, expected)) return false;
 
-  // Single-use, atomically. The KV read above is not the gate — this claim is:
-  // concurrent submissions of the same token all reach here, and only the first
-  // claim succeeds, so a captured token cannot be redeemed twice.
+  const exp = Number(expStr);
+  if (!Number.isFinite(exp) || exp <= Date.now()) return false;
+
+  // Single-use, atomically via the D1 replay-claim table. Concurrent
+  // submissions of the same token all reach here; only the first claim wins, so
+  // a captured token cannot be redeemed twice — and since the token is
+  // deterministic per challenge, one solved challenge admits exactly one gate.
   return claimReplayValue(
     env.DB,
     "cap-token",
     "",
-    tokenKey,
-    Math.ceil(expires / 1000),
+    sig,
+    Math.ceil(exp / 1000),
   );
 }
 

--- a/worker/lib/config.ts
+++ b/worker/lib/config.ts
@@ -162,31 +162,48 @@ export async function getConfig(db: D1Database): Promise<SiteConfig> {
  * Bridge the pre-switchable-set captcha config into the new model, in memory,
  * on every read. A site configured before `captcha_providers` existed has only
  * the legacy `captcha_provider` + shared `captcha_site_key`/`captcha_secret_key`
- * stored; derive the ordered set from it and copy the shared credentials into
- * the matching provider's per-provider slot so verification finds them.
+ * stored.
  *
- * Runs only when `captcha_providers` was never written (still the empty
- * default) — once an admin saves the new config, the stored list wins and this
- * is a no-op. Secrets are copied as-is (still ciphertext at this stage); the
- * per-provider secret keys are in SENSITIVE_CONFIG_KEYS, so decryptConfigSecrets
- * handles them downstream exactly like the legacy field.
+ * Two independent concerns, because the credential copy must keep working after
+ * the ordered set is persisted:
+ *
+ *   1. Seed `captcha_providers` from the legacy single provider — only while the
+ *      list is still unset. Once an admin saves a set, the stored list wins.
+ *   2. Backfill a provider's per-provider credential slot from the legacy
+ *      shared pair whenever that slot is still empty. This is NOT gated on (1):
+ *      an admin who saves `captcha_providers` (adding alternates) never
+ *      re-enters the default provider's key, and the legacy shared value was
+ *      never persisted into `<provider>_site_key`. Gating both on the same
+ *      condition is exactly what left Turnstile rendering with an empty sitekey.
+ *
+ * Secrets are copied as-is (still ciphertext at this stage); the per-provider
+ * secret keys are in SENSITIVE_CONFIG_KEYS, so decryptConfigSecrets handles them
+ * downstream exactly like the legacy field.
  */
 function migrateLegacyCaptcha(config: SiteConfig): void {
-  if (config.captcha_providers.length > 0) return;
   const legacy = config.captcha_provider;
   if (!legacy || legacy === "none") return;
 
-  config.captcha_providers = [legacy];
+  // (1) Seed the ordered set from the legacy single provider.
+  if (config.captcha_providers.length === 0) {
+    config.captcha_providers = [legacy];
+  }
 
+  // (2) Backfill the legacy provider's credentials whenever its new slot is
+  // empty — independent of whether the set above was just seeded or was
+  // already persisted. Only turnstile/hcaptcha/recaptcha shared the legacy
+  // pair; pow has no keys and geetest/cap post-date the legacy field.
   const bag = configBag(config);
   const siteKeyField = `${legacy}_site_key`;
   const secretKeyField = `${legacy}_secret_key`;
-  // Only turnstile/hcaptcha/recaptcha shared the legacy pair. pow has no keys;
-  // geetest/cap did not exist before the migration, so nothing to copy.
-  if (siteKeyField in config && !bag[siteKeyField]) {
+  if (siteKeyField in config && !bag[siteKeyField] && config.captcha_site_key) {
     bag[siteKeyField] = config.captcha_site_key;
   }
-  if (secretKeyField in config && !bag[secretKeyField]) {
+  if (
+    secretKeyField in config &&
+    !bag[secretKeyField] &&
+    config.captcha_secret_key
+  ) {
     bag[secretKeyField] = config.captcha_secret_key;
   }
 }

--- a/worker/lib/securityState.ts
+++ b/worker/lib/securityState.ts
@@ -2,11 +2,7 @@ import { sha256Hex } from "./crypto";
 
 const SWEEP_BATCH_SIZE = 5_000;
 
-export type ReplayClaimType =
-  | "dpop"
-  | "client-assertion"
-  | "cap-nonce"
-  | "cap-token";
+export type ReplayClaimType = "dpop" | "client-assertion" | "cap-token";
 
 /**
  * Claim a replay-sensitive value exactly once for its validity window.


### PR DESCRIPTION
Fixes reported on the live instance: Turnstile fails to load, Cap verification fails, "too many requests" on switching, and the admin reorder controls not moving rows. (Credentials confirmed correct by the operator.)

## Root causes & fixes

### 1. Turnstile renders with an empty sitekey
The legacy→per-provider credential migration (`migrateLegacyCaptcha`) was gated entirely on `captcha_providers` being unset. Once an admin **saved** a provider set, the migration stopped running, and `turnstile_site_key` — which was only ever populated *in memory* by that migration and never persisted — read back as `""`, so the widget got `sitekey: ""`.

**Fix:** split the migration into two independent concerns — seed the ordered set only when it's unset, but **backfill a provider's per-provider credentials from the legacy shared pair whenever the per-provider slot is still empty**, regardless of whether the set is persisted.

### 2. Cap verification fails ("redeem called twice, second fails")
`@cap.js/widget` performs a **speculative redeem + a final redeem** for a single solve. The atomic nonce-consumption at `/redeem` made the second call fail (`already_redeemed`), which the widget surfaced as `invalid_solution`.

**Fix:** make redeem **idempotent** — the redeem token is now derived deterministically from the challenge (`sig.exp.HMAC(secret)`), so both redeems return the same token and one solved challenge yields exactly one token. Single use is still enforced **once, at the gate**, via the atomic D1 replay-claim table (`claimReplayValue`). No KV, no consumeNonce, PoW cost preserved.

### 3. "Too many requests" on switching / GeeTest network errors
The per-provider widget effects listed the `captcha` object and `onVerified`/`onError`/`t` as dependencies. Those identities change on any parent re-render (e.g. every keystroke in the login form), tearing down and re-creating each widget — re-fetching PoW/Cap challenges and re-initialising the GeeTest widget on every render.

**Fix:** read callbacks and `t` through refs; the effects now depend only on `provider` and the primitive config values they actually use, so a provider mounts once per activation.

### 4. Admin reorder doesn't move rows
The alternates editor iterated a fixed provider order, so `↑`/`↓` changed stored order but nothing moved on screen.

**Fix:** render enabled alternates in their configured order, with not-yet-enabled methods pinned at the bottom.

## Testing
`bunx tsc -b` ✅ · `bun run lint` ✅ · `bun test` (84 pass) ✅ · `bun run build` ✅ · `bun run docs:build` ✅

Docs (`architecture`, `configuration` + zh mirrors) updated for the new Cap redeem model.

## Sourcery 总结

修复影响实时身份验证和管理流程的 CAPTCHA 迁移、兑换、小组件生命周期及提供商排序问题。

错误修复：
- 当缺少特定提供商设置时恢复旧版 CAPTCHA 凭据，包括提供商列表已持久化之后的情况。
- 使嵌入式 Cap 兑换具备幂等性，同时在身份验证入口保留单次使用限制。
- 防止 CAPTCHA 小组件因无关的父组件重新渲染而重新挂载，避免重复发起挑战请求和初始化 GeeTest。
- 修复管理端 CAPTCHA 备用提供商的排序控件，使配置的行移动能够反映在编辑器中。

增强功能：
- 更新架构和配置文档，说明确定性的 Cap 令牌以及基于 D1 的重放保护。

文档：
- 更新英文和中文架构及配置文档，以说明修订后的嵌入式 Cap 兑换模型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix CAPTCHA migration, redemption, widget lifecycle, and provider ordering issues affecting live authentication and administration flows.

Bug Fixes:
- Restore legacy CAPTCHA credentials when provider-specific settings are missing, including after provider lists have been persisted.
- Make embedded Cap redemption idempotent while preserving single-use enforcement at the authentication gate.
- Prevent CAPTCHA widgets from remounting on unrelated parent renders, avoiding repeated challenge requests and GeeTest initialization.
- Fix admin CAPTCHA alternate-provider reorder controls so configured row movement is reflected in the editor.

Enhancements:
- Update architecture and configuration documentation to describe deterministic Cap tokens and D1-based replay protection.

Documentation:
- Update English and Chinese architecture and configuration documentation for the revised embedded Cap redemption model.

</details>